### PR TITLE
Added signed integer arithmetic for investor balance.

### DIFF
--- a/src/wallet/investor.cpp
+++ b/src/wallet/investor.cpp
@@ -411,13 +411,13 @@ uint64_t Investor::GlobalBalance(void)
 {
    LOCK(csInvestor);
     
-    uint64_t balance = 0;
+    int64_t balance = 0;
     
     for (auto&& period : HoldingPeriods) {
         balance += period.balance;
     }
-    
-    return balance;
+
+    return ((balance > 0) ? (uint64_t)balance : 0);
 }
 
 void Investor::UpdateGlobalBalance(const CWallet& wallet)

--- a/src/wallet/investor.h
+++ b/src/wallet/investor.h
@@ -114,7 +114,7 @@ private:
         CScript redeemScript;
 
         // the current balance of the multisig address
-        uint64_t balance;
+        int64_t balance;
     } HoldingPeriod;
 
     std::vector<HoldingPeriod> HoldingPeriods;


### PR DESCRIPTION
In order to avoid unsigned integer underflows in the investor balance calculations, the signed arithmetic has been enforced.