### PR TITLE
Wallet: Checking for failed EncryptPinCode() and EncryptPaperKey() calls

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -843,8 +843,14 @@ bool CWallet::EncryptWallet(const SecureString& strWalletPassphrase, const bool 
         bool generateNewPaperKey = generateNewMasterKey;
         if (IsHDEnabled()) {
             generateNewPaperKey = false;
-            EncryptPinCode(_vMasterKey);
-            EncryptPaperKey(_vMasterKey);
+            if (!EncryptPinCode(_vMasterKey) || !EncryptPaperKey(_vMasterKey))
+            {
+                pwalletdbEncryption->TxnAbort();
+                delete pwalletdbEncryption;
+                // We now have the PIN Code and/or the Paper Key unencrypted in memory...
+                // die and let the user reload the unencrypted wallet.
+                assert(false);
+            }
         }
 
         if (!EncryptKeys(_vMasterKey))


### PR DESCRIPTION
If either the EncryptPinCode() or EncryptPaperKey() call fail (or bothfail ), the wallet will remain with unencrypted versions of PIN Code and/or Paper Key. This patch adds a check (the same as for EncryptKeys()) that terminates the program and leaves the whole wallet unencrypted if any of these calls fail.