### PR TITLE
Hide Encrypt Wallet options from UI

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,6 +106,13 @@ AC_ARG_ENABLE([wallet],
   [enable_wallet=$enableval],
   [enable_wallet=yes])
 
+# Disable encrypt wallet
+AC_ARG_ENABLE([encrypt-wallet],
+  [AS_HELP_STRING([--enable-encrypt-wallet],
+  [enable encrypt wallet (disabled by default)])],
+  [enable_encrypt_wallet=$enableval],
+  [enable_encrypt_wallet=no])
+
 # Enable lite variant
 AC_ARG_ENABLE([variant_lite],
   [AS_HELP_STRING([--disable-variant-lite],
@@ -1086,6 +1093,15 @@ else
   AC_MSG_RESULT(no)
 fi
 
+dnl enable encrypt wallet
+AC_MSG_CHECKING([if wallet encryption should be enabled])
+if test x$enable_encrypt_wallet != xno; then
+  AC_MSG_RESULT(yes)
+  AC_DEFINE_UNQUOTED([ENABLE_ENCRYPT_WALLET],[1],[Define to 1 to enable wallet encryption])
+else
+  AC_MSG_RESULT(no)
+fi
+
 dnl enable upnp support
 AC_MSG_CHECKING([whether to build with support for UPnP])
 if test x$have_miniupnpc = xno; then
@@ -1188,6 +1204,7 @@ AM_CONDITIONAL([TARGET_DARWIN], [test x$TARGET_OS = xdarwin])
 AM_CONDITIONAL([BUILD_DARWIN], [test x$BUILD_OS = xdarwin])
 AM_CONDITIONAL([TARGET_WINDOWS], [test x$TARGET_OS = xwindows])
 AM_CONDITIONAL([ENABLE_WALLET],[test x$enable_wallet = xyes])
+AM_CONDITIONAL([ENABLE_ENCRYPT_WALLET],[test x$enable_encrypt_wallet = xyes])
 AM_CONDITIONAL([ENABLE_TESTS],[test x$BUILD_TEST = xyes])
 AM_CONDITIONAL([ENABLE_QT],[test x$paicoin_enable_qt = xyes])
 AM_CONDITIONAL([ENABLE_QT_TESTS],[test x$BUILD_TEST_QT = xyes])
@@ -1317,29 +1334,30 @@ esac
 
 echo
 echo "Options used to compile and link:"
-echo "  with wallet   = $enable_wallet"
-echo "  lite variant  = $variant_lite"
-echo "  with gui / qt = $paicoin_enable_qt"
+echo "  with wallet         = $enable_wallet"
+echo "  with encrypt wallet = $enable_encrypt_wallet"
+echo "  lite variant        = $variant_lite"
+echo "  with gui / qt       = $paicoin_enable_qt"
 if test x$paicoin_enable_qt != xno; then
-    echo "    qt version  = $paiup_got_major_vers"
-    echo "    with qr     = $use_qr"
+    echo "    qt version    = $paiup_got_major_vers"
+    echo "    with qr       = $use_qr"
 fi
-echo "  with zmq      = $use_zmq"
-echo "  with test     = $use_tests"
-echo "  with bench    = $use_bench"
-echo "  with upnp     = $use_upnp"
-echo "  use asm       = $use_asm"
-echo "  debug enabled = $enable_debug"
-echo "  werror        = $enable_werror"
+echo "  with zmq            = $use_zmq"
+echo "  with test           = $use_tests"
+echo "  with bench          = $use_bench"
+echo "  with upnp           = $use_upnp"
+echo "  use asm             = $use_asm"
+echo "  debug enabled       = $enable_debug"
+echo "  werror              = $enable_werror"
 echo
-echo "  target os     = $TARGET_OS"
-echo "  build os      = $BUILD_OS"
+echo "  target os           = $TARGET_OS"
+echo "  build os            = $BUILD_OS"
 echo
-echo "  CC            = $CC"
-echo "  CFLAGS        = $CFLAGS"
-echo "  CPPFLAGS      = $CPPFLAGS"
-echo "  CXX           = $CXX"
-echo "  CXXFLAGS      = $CXXFLAGS"
-echo "  LDFLAGS       = $LDFLAGS"
-echo "  ARFLAGS       = $ARFLAGS"
+echo "  CC                  = $CC"
+echo "  CFLAGS              = $CFLAGS"
+echo "  CPPFLAGS            = $CPPFLAGS"
+echo "  CXX                 = $CXX"
+echo "  CXXFLAGS            = $CXXFLAGS"
+echo "  LDFLAGS             = $LDFLAGS"
+echo "  ARFLAGS             = $ARFLAGS"
 echo

--- a/src/qt/paicoingui.cpp
+++ b/src/qt/paicoingui.cpp
@@ -123,9 +123,11 @@ PAIcoinGUI::PAIcoinGUI(const PlatformStyle *_platformStyle, const NetworkStyle *
     receiveCoinsMenuAction(0),
     optionsAction(0),
     toggleHideAction(0),
+    #ifdef ENABLE_ENCRYPT_WALLET
     encryptWalletAction(0),
-    backupWalletAction(0),
     changePassphraseAction(0),
+    #endif
+    backupWalletAction(0),
     aboutQtAction(0),
     openRPCConsoleAction(0),
     openAction(0),
@@ -432,13 +434,15 @@ void PAIcoinGUI::createActions()
     toggleHideAction = new QAction(platformStyle->TextColorIcon(":/icons/about"), tr("&Show / Hide"), this);
     toggleHideAction->setStatusTip(tr("Show or hide the main Window"));
 
+#ifdef ENABLE_ENCRYPT_WALLET
     encryptWalletAction = new QAction(platformStyle->TextColorIcon(":/icons/lock_closed"), tr("&Encrypt Wallet..."), this);
     encryptWalletAction->setStatusTip(tr("Encrypt the private keys that belong to your wallet"));
     encryptWalletAction->setCheckable(true);
-    backupWalletAction = new QAction(platformStyle->TextColorIcon(":/icons/filesave"), tr("&Backup Wallet..."), this);
-    backupWalletAction->setStatusTip(tr("Backup wallet to another location"));
     changePassphraseAction = new QAction(platformStyle->TextColorIcon(":/icons/key"), tr("&Change Passphrase..."), this);
     changePassphraseAction->setStatusTip(tr("Change the passphrase used for wallet encryption"));
+#endif // ENABLE_ENCRYPT_WALLET
+    backupWalletAction = new QAction(platformStyle->TextColorIcon(":/icons/filesave"), tr("&Backup Wallet..."), this);
+    backupWalletAction->setStatusTip(tr("Backup wallet to another location"));
     signMessageAction = new QAction(platformStyle->TextColorIcon(":/icons/edit"), tr("Sign &message..."), this);
     signMessageAction->setStatusTip(tr("Sign messages with your PAIcoin addresses to prove you own them"));
     verifyMessageAction = new QAction(platformStyle->TextColorIcon(":/icons/verify"), tr("&Verify message..."), this);
@@ -477,9 +481,11 @@ void PAIcoinGUI::createActions()
 #ifdef ENABLE_WALLET
     if(walletFrame)
     {
+#ifdef ENABLE_ENCRYPT_WALLET
         connect(encryptWalletAction, SIGNAL(triggered(bool)), walletFrame, SLOT(encryptWallet(bool)));
-        connect(backupWalletAction, SIGNAL(triggered()), walletFrame, SLOT(backupWallet()));
         connect(changePassphraseAction, SIGNAL(triggered()), walletFrame, SLOT(changePassphrase()));
+#endif // ENABLE_ENCRYPT_WALLET
+        connect(backupWalletAction, SIGNAL(triggered()), walletFrame, SLOT(backupWallet()));
         connect(signMessageAction, SIGNAL(triggered()), this, SLOT(gotoSignMessageTab()));
         connect(verifyMessageAction, SIGNAL(triggered()), this, SLOT(gotoVerifyMessageTab()));
         connect(usedSendingAddressesAction, SIGNAL(triggered()), walletFrame, SLOT(usedSendingAddresses()));
@@ -523,8 +529,10 @@ void PAIcoinGUI::createMenuBar()
     QMenu *settings = appMenuBar->addMenu(tr("&Settings"));
     if(walletFrame)
     {
+#ifdef ENABLE_ENCRYPT_WALLET
         settings->addAction(encryptWalletAction);
         settings->addAction(changePassphraseAction);
+#endif // ENABLE_ENCRYPT_WALLET
         settings->addAction(viewInvestorKeyAction);
         settings->addSeparator();
     }
@@ -653,9 +661,11 @@ void PAIcoinGUI::setWalletActionsEnabled(bool enabled)
     receiveCoinsAction->setEnabled(enabled);
     receiveCoinsMenuAction->setEnabled(enabled);
     historyAction->setEnabled(enabled);
+#ifdef ENABLE_ENCRYPT_WALLET
     encryptWalletAction->setEnabled(enabled);
-    backupWalletAction->setEnabled(enabled);
     changePassphraseAction->setEnabled(enabled);
+#endif // ENABLE_ENCRYPT_WALLET
+    backupWalletAction->setEnabled(enabled);
     signMessageAction->setEnabled(enabled);
     verifyMessageAction->setEnabled(enabled);
     usedSendingAddressesAction->setEnabled(enabled);
@@ -1430,14 +1440,15 @@ void PAIcoinGUI::setHDStatus(int hdEnabled)
     labelWalletHDStatusIcon->setEnabled(hdEnabled);
 }
 
+#ifdef ENABLE_ENCRYPT_WALLET
 void PAIcoinGUI::setEncryptionStatus(int status)
 {
     switch(status)
     {
     case WalletModel::Unencrypted:
         labelWalletEncryptionIcon->hide();
-        encryptWalletAction->setChecked(false);
         changePassphraseAction->setEnabled(false);
+        encryptWalletAction->setChecked(false);
         encryptWalletAction->setEnabled(true);
         break;
     case WalletModel::Unlocked:
@@ -1458,6 +1469,8 @@ void PAIcoinGUI::setEncryptionStatus(int status)
         break;
     }
 }
+#endif // ENABLE_ENCRYPT_WALLET
+
 #endif // ENABLE_WALLET
 
 void PAIcoinGUI::showNormalIfMinimized(bool fToggleHidden)

--- a/src/qt/paicoingui.h
+++ b/src/qt/paicoingui.h
@@ -137,9 +137,11 @@ private:
     QAction *receiveCoinsMenuAction;
     QAction *optionsAction;
     QAction *toggleHideAction;
+#ifdef ENABLE_ENCRYPT_WALLET
     QAction *encryptWalletAction;
-    QAction *backupWalletAction;
     QAction *changePassphraseAction;
+#endif // ENABLE_ENCRYPT_WALLET
+    QAction *backupWalletAction;
     QAction *aboutQtAction;
     QAction *openRPCConsoleAction;
     QAction *openAction;
@@ -224,11 +226,14 @@ public Q_SLOTS:
     void message(const QString &title, const QString &message, unsigned int style, bool *ret = nullptr);
 
 #ifdef ENABLE_WALLET
+
+#ifdef ENABLE_ENCRYPT_WALLET
     /** Set the encryption status as shown in the UI.
        @param[in] status            current encryption status
        @see WalletModel::EncryptionStatus
     */
     void setEncryptionStatus(int status);
+#endif // ENABLE_ENCRYPT_WALLET
 
     /** Set the hd-enabled status as shown in the UI.
      @param[in] status            current hd enabled status

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -97,8 +97,10 @@ void WalletView::setPAIcoinGUI(PAIcoinGUI *gui)
         // Receive and report messages
         connect(this, SIGNAL(message(QString,QString,unsigned int)), gui, SLOT(message(QString,QString,unsigned int)));
 
+#ifdef ENABLE_ENCRYPT_WALLET
         // Pass through encryption status changed signals
         connect(this, SIGNAL(encryptionStatusChanged(int)), gui, SLOT(setEncryptionStatus(int)));
+#endif // ENABLE_ENCRYPT_WALLET
 
         // Pass through transaction notifications
         connect(this, SIGNAL(incomingTransaction(QString,int,CAmount,QString,QString,QString)), gui, SLOT(incomingTransaction(QString,int,CAmount,QString,QString,QString)));


### PR DESCRIPTION
Added an option to configure script to
re-enable Encrypt Wallet option once
particular feature gets fully supported.
By default, Encrypt Wallet will be disabled.