### PR TITLE
Clean-up paicoincore.org references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - CCACHE_TEMPDIR=/tmp/.ccache-temp
     - CCACHE_COMPRESS=1
     - BASE_OUTDIR=$TRAVIS_BUILD_DIR/out
-    - SDK_URL=https://paicoincore.org/depends-sources/sdks
+    - SDK_URL=https://bitcoincore.org/depends-sources/sdks
     - PYTHON_DEBUG=1
     - WINEDEBUG=fixme-all
   matrix:

--- a/doc/README.md
+++ b/doc/README.md
@@ -5,8 +5,6 @@ Setup
 ---------------------
 PAIcoin Core is the original PAIcoin client and it builds the backbone of the network. It downloads and, by default, stores the entire history of PAIcoin transactions (which is currently more than 100 GBs); depending on the speed of your computer and network connection, the synchronization process can take anywhere from a few hours to a day or more.
 
-To download PAIcoin Core, visit [paicoincore.org](https://paicoincore.org/en/releases/).
-
 Running
 ---------------------
 The following are some helpful notes on how to run PAIcoin on your native platform.

--- a/doc/man/paicoin-cli.1
+++ b/doc/man/paicoin-cli.1
@@ -74,7 +74,7 @@ Read extra arguments from standard input, one per line until EOF/Ctrl\-D
 Copyright (C) 2009-2017 The Bitcoin Core developers
 
 Please contribute if you find PAIcoin Core useful. Visit
-<https://paicoincore.org> for further information about the software.
+<https://projectpai.com> for further information about the software.
 The source code is available from <https://github.com/projectpai/paicoin>.
 
 This is experimental software.

--- a/doc/man/paicoin-qt.1
+++ b/doc/man/paicoin-qt.1
@@ -534,7 +534,7 @@ Reset all settings changed in the GUI
 Copyright (C) 2009-2017 The Bitcoin Core developers
 
 Please contribute if you find PAIcoin Core useful. Visit
-<https://paicoincore.org> for further information about the software.
+<https://projectpai.com> for further information about the software.
 The source code is available from <https://github.com/projectpai/paicoin>.
 
 This is experimental software.

--- a/doc/man/paicoin-tx.1
+++ b/doc/man/paicoin-tx.1
@@ -110,7 +110,7 @@ Set register NAME to given JSON\-STRING
 Copyright (C) 2009-2017 The Bitcoin Core developers
 
 Please contribute if you find PAIcoin Core useful. Visit
-<https://paicoincore.org> for further information about the software.
+<https://projectpai.com> for further information about the software.
 The source code is available from <https://github.com/projectpai/paicoin>.
 
 This is experimental software.

--- a/doc/man/paicoind.1
+++ b/doc/man/paicoind.1
@@ -513,7 +513,7 @@ Set the number of threads to service RPC calls (default: 4)
 Copyright (C) 2009-2017 The Bitcoin Core developers
 
 Please contribute if you find PAIcoin Core useful. Visit
-<https://paicoincore.org> for further information about the software.
+<https://projectpai.com> for further information about the software.
 The source code is available from <https://github.com/projectpai/paicoin>.
 
 This is experimental software.

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -14,6 +14,6 @@ CMD curl -L http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz -o /tmp/d
     curl -L --user $GIT_USER:$GIT_PASSWD https://github.com/projectpai/paicoin/tarball/paicoin-initial -o /tmp/paicoin.tgz && \
     mkdir /paicoin-$VERSION && tar xfz /tmp/paicoin.tgz --strip 1 -C /paicoin-$VERSION && cd /paicoin-$VERSION && \
     ./autogen.sh && ./configure --disable-bench --prefix=/usr/local && \
-    make && checkinstall -y --maintainer paicoincore.org --install=no --nodoc --strip --pkgname paicoin --provides paicoin \
+    make && checkinstall -y --maintainer projectpai.com --install=no --nodoc --strip --pkgname paicoin --provides paicoin \
       --exclude /usr/local/bin/test_paicoin,/usr/local/lib,/usr/local/include \
       --pkgversion $VERSION --pkgrelease 1 --pkgsource https://github.com/projectpai/paicoin --pakdir /paicoin 


### PR DESCRIPTION
There are a few references in the documentation to paicoincore.org and they have been updated accordingly.

GitLab ticket: http://gitlab.int.oben.me/ticket-tracking/pai-up-desktop-tickets/issues/5