### PR TITLE
Wallet: Set FEATURE_LATEST to be FEATURE_HD_SPLIT and properly init on first run

### DIFF
--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4307,6 +4307,14 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile, bool& fFirs
         }
 
         walletInstance->SetMinVersion(FEATURE_LATEST);
+
+        // Top up the keypool
+        if (!walletInstance->TopUpKeyPool()) {
+            InitError(_("Unable to generate initial keys") += "\n");
+            return nullptr;
+        }
+
+        walletInstance->SetBestChain(chainActive.GetLocator());
     }
     else if (gArgs.IsArgSet("-usehd")) {
         bool useHD = gArgs.GetBoolArg("-usehd", true);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -4305,6 +4305,8 @@ CWallet* CWallet::CreateWalletFromFile(const std::string walletFile, bool& fFirs
             InitError(strprintf(_("Error creating %s: You can't create non-HD wallets with this version."), walletFile));
             return nullptr;
         }
+
+        walletInstance->SetMinVersion(FEATURE_LATEST);
     }
     else if (gArgs.IsArgSet("-usehd")) {
         bool useHD = gArgs.GetBoolArg("-usehd", true);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -95,7 +95,7 @@ enum WalletFeature
 
     FEATURE_HD_SPLIT = 139900, // Wallet with HD chain split (change outputs will use m/0'/1'/k)
 
-    FEATURE_LATEST = FEATURE_COMPRPUBKEY // HD is optional, use FEATURE_COMPRPUBKEY as latest version
+    FEATURE_LATEST = FEATURE_HD_SPLIT
 };
 
 


### PR DESCRIPTION
Wallet: Since we removed the "usehd" option, set the FEATURE_LATEST to be FEATURE_HD_SPLIT. Additionally, set the min version to FEATURE_LATEST on first run. Moreover, add keypool and best chain init code on first run.