### PR TITLE
Update macOS deployment binary and settings

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -13,7 +13,7 @@ How to Upgrade
 
 If you are running an older version, shut it down. Wait until it has completely
 shut down (which might take a few minutes for older versions), then run the 
-installer (on Windows) or just copy over /Applications/PAIcoin-Core (on Mac)
+installer (on Windows) or just copy over /Applications/PAI-Up (on Mac)
 or `paicoind`/`paiup` (on Linux).
 
 The first time you run version 0.15.0, your chainstate database will be converted to a

--- a/share/qt/Info.plist.in
+++ b/share/qt/Info.plist.in
@@ -29,10 +29,10 @@
   <string>????</string>
 
   <key>CFBundleExecutable</key>
-  <string>PAIcoin-Core</string>
+  <string>PAI-Up</string>
   
   <key>CFBundleName</key>
-  <string>PAIcoin-Core</string>
+  <string>PAI-Up</string>
 
   <key>LSHasLocalizedDisplayName</key>
   <true/>


### PR DESCRIPTION
Solved the wrong binary reference in the macOS deployment. Updated the documentation.

GitLab ticket: http://gitlab.int.oben.me/ticket-tracking/pai-up-desktop-tickets/issues/16