### PR TITLE
Wallet: Fix compiler errors for variable length arrays (-Wvla) in PaperKey handling 

### DIFF
--- a/src/support/allocators/secure.h
+++ b/src/support/allocators/secure.h
@@ -55,4 +55,8 @@ struct secure_allocator : public std::allocator<T> {
 // This is exactly like std::string, but with a custom allocator.
 typedef std::basic_string<char, std::char_traits<char>, secure_allocator<char> > SecureString;
 
+// This is exactly like std::vector<T>, but with a secure allocator.
+template <typename T>
+using SecureVector = std::vector<T, secure_allocator<T>>;
+
 #endif // PAICOIN_SUPPORT_ALLOCATORS_SECURE_H

--- a/src/util.h
+++ b/src/util.h
@@ -26,6 +26,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include <cstddef>
 
 #include <boost/signals2/signal.hpp>
 
@@ -329,5 +330,14 @@ template <typename Callable> void TraceThread(const char* name,  Callable func)
 std::string CopyrightHolders(int beginning, int current);
 
 std::string CopyrightHolders(const std::string& strPrefix);
+
+/**
+ * Returns the size of a container in bytes.
+ */
+template <typename C>
+std::size_t sizeInBytes(const C& c)
+{
+    return c.size() * sizeof(typename C::value_type);
+}
 
 #endif // PAICOIN_UTIL_H

--- a/src/wallet/bip39mnemonic.cpp
+++ b/src/wallet/bip39mnemonic.cpp
@@ -12,6 +12,7 @@
 #include "../crypto/common.h"
 #include "../crypto/sha256.h"
 #include "../crypto/hmac_sha512.h"
+#include "../util.h"
 
 #define be32(x) ((((x) & 0xff) << 24) | (((x) & 0xff00) << 8) | (((x) & 0xff0000) >> 8) | (((x) & 0xff000000) >> 24))
 
@@ -180,14 +181,14 @@ void BIP39Mnemonic::PBKDF2(void *dk, const void *pw, size_t pwLen, const void *s
 
         // U1 = hmac_hash(pw, salt || be32(i))
         CHMAC_SHA512 hmacSha512s((const unsigned char*)pw, pwLen);
-        hmacSha512s.Write(s.data(), s.size());
+        hmacSha512s.Write(s.data(), sizeInBytes(s));
         hmacSha512s.Finalize((unsigned char*)U.data());
-        memcpy(T.data(), U.data(), U.size());
+        memcpy(T.data(), U.data(), sizeInBytes(U));
 
         for (unsigned r = 1; r < rounds; r++) {
             // Urounds = hmac_hash(pw, Urounds-1)
             CHMAC_SHA512 hmacSha512u((const unsigned char*)pw, pwLen);
-            hmacSha512u.Write((const unsigned char*)U.data(), U.size());
+            hmacSha512u.Write((const unsigned char*)U.data(), sizeInBytes(U));
             hmacSha512u.Finalize((unsigned char*)U.data());
             for (j = 0; j < hashLen/sizeof(uint32_t); j++) T[j] ^= U[j]; // Ti = U1 ^ U2 ^ ... ^ Urounds
         }

--- a/src/wallet/bip39mnemonic.cpp
+++ b/src/wallet/bip39mnemonic.cpp
@@ -6,6 +6,8 @@
 #include "bip39mnemonic.h"
 #include <assert.h>
 #include <string.h>
+#include <vector>
+#include "../support/allocators/secure.h"
 #include "../support/cleanse.h"
 #include "../crypto/common.h"
 #include "../crypto/sha256.h"
@@ -14,6 +16,8 @@
 #define be32(x) ((((x) & 0xff) << 24) | (((x) & 0xff00) << 8) | (((x) & 0xff0000) >> 8) | (((x) & 0xff000000) >> 24))
 
 using namespace std;
+
+using SecureByteVector = SecureVector<uint8_t>;
 
 BIP39Mnemonic::BIP39Mnemonic()
 {
@@ -27,7 +31,7 @@ BIP39Mnemonic::~BIP39Mnemonic()
 size_t BIP39Mnemonic::Encode(char *phrase, size_t phraseLen, const uint8_t *data, size_t dataLen)
 {
     uint32_t x;
-    uint8_t buf[dataLen + 32];
+    SecureByteVector buf(dataLen + 32);
     const char *word;
     size_t i, len = 0;
 
@@ -36,7 +40,7 @@ size_t BIP39Mnemonic::Encode(char *phrase, size_t phraseLen, const uint8_t *data
     assert(dataLen > 0 && (dataLen % 4) == 0);
     if (! data || (dataLen % 4) != 0) return 0; // data length must be a multiple of 32 bits
 
-    memcpy(buf, data, dataLen);
+    memcpy(buf.data(), data, dataLen);
 
     // append SHA256 checksum
     CSHA256 sha256;
@@ -54,7 +58,6 @@ size_t BIP39Mnemonic::Encode(char *phrase, size_t phraseLen, const uint8_t *data
 
     memory_cleanse(&word, strlen(word));
     memory_cleanse(&x, sizeof(x));
-    memory_cleanse(buf, sizeof(buf));
     return (! phrase || len + 1 <= phraseLen) ? len + 1 : 0;
 }
 
@@ -83,7 +86,7 @@ size_t BIP39Mnemonic::Decode(uint8_t *data, size_t dataLen, const char *phrase)
     }
 
     if ((count % 3) == 0 && (! word || *word == '\0')) { // check that phrase has correct number of words
-        uint8_t buf[(count*11 + 7)/8];
+        SecureByteVector buf((count*11 + 7)/8);
 
         for (i = 0; i < (count*11 + 7)/8; i++) {
             x = idx[i*8/11];
@@ -93,15 +96,13 @@ size_t BIP39Mnemonic::Decode(uint8_t *data, size_t dataLen, const char *phrase)
         }
 
         CSHA256 sha256;
-        sha256.Write((const uint8_t *)buf, count*4/3);
+        sha256.Write((const uint8_t *)buf.data(), count*4/3);
         sha256.Finalize(hash);
 
         if (b >> (8 - count/3) == (hash[0] >> (8 - count/3))) { // verify checksum
             r = count*4/3;
-            if (data && r <= dataLen) memcpy(data, buf, r);
+            if (data && r <= dataLen) memcpy(data, buf.data(), r);
         }
-
-        memory_cleanse(buf, sizeof(buf));
     }
 
     memory_cleanse(&b, sizeof(b));
@@ -120,16 +121,15 @@ int BIP39Mnemonic::PhraseIsValid(const char *phrase)
 
 void BIP39Mnemonic::DeriveKey(void *key64, const char *phrase, const char *passphrase)
 {
-    char salt[strlen("mnemonic") + (passphrase ? strlen(passphrase) : 0) + 1];
+    SecureString salt(strlen("mnemonic") + (passphrase ? strlen(passphrase) : 0) + 1, '\0');
 
     assert(key64 != NULL);
     assert(phrase != NULL);
 
     if (phrase) {
-        strcpy(salt, "mnemonic");
-        if (passphrase) strcpy(salt + strlen("mnemonic"), passphrase);
-        PBKDF2(key64, phrase, strlen(phrase), salt, strlen(salt));
-        memory_cleanse(salt, sizeof(salt));
+        salt = "mnemonic";
+        if (passphrase) salt += passphrase;
+        PBKDF2(key64, phrase, strlen(phrase), salt.c_str(), salt.size());
     }
 }
 
@@ -162,8 +162,11 @@ void BIP39Mnemonic::PBKDF2(void *dk, const void *pw, size_t pwLen, const void *s
     // ...
     // Urounds = hmac_hash(pw, Urounds-1)
 
-    uint8_t s[saltLen + sizeof(uint32_t)];
-    uint32_t i, j, U[hashLen/sizeof(uint32_t)], T[hashLen/sizeof(uint32_t)];
+    using SecureUInt32Vector = SecureVector<uint32_t>;
+
+    SecureByteVector s(saltLen + sizeof(uint32_t));
+    uint32_t i, j;
+    SecureUInt32Vector U(hashLen/sizeof(uint32_t)), T(hashLen/sizeof(uint32_t));
 
     assert(dk != NULL || dkLen == 0);
     assert(hashLen > 0 && (hashLen % 4) == 0);
@@ -171,31 +174,27 @@ void BIP39Mnemonic::PBKDF2(void *dk, const void *pw, size_t pwLen, const void *s
     assert(salt != NULL || saltLen == 0);
     assert(rounds > 0);
 
-    memcpy(s, salt, saltLen);
+    memcpy(s.data(), salt, saltLen);
 
     for (i = 0; i < (dkLen + hashLen - 1)/hashLen; i++) {
         j = be32(i + 1);
-        memcpy(s + saltLen, &j, sizeof(j));
+        memcpy(s.data() + saltLen, &j, sizeof(j));
 
         // U1 = hmac_hash(pw, salt || be32(i))
         CHMAC_SHA512 hmacSha512s((const unsigned char*)pw, pwLen);
-        hmacSha512s.Write(s, sizeof(s));
-        hmacSha512s.Finalize((unsigned char*)U);
-        memcpy(T, U, sizeof(U));
+        hmacSha512s.Write(s.data(), sizeof(s));
+        hmacSha512s.Finalize((unsigned char*)U.data());
+        memcpy(T.data(), U.data(), U.size());
 
         for (unsigned r = 1; r < rounds; r++) {
             // Urounds = hmac_hash(pw, Urounds-1)
             CHMAC_SHA512 hmacSha512u((const unsigned char*)pw, pwLen);
-            hmacSha512u.Write((const unsigned char*)U, sizeof(U));
-            hmacSha512u.Finalize((unsigned char*)U);
+            hmacSha512u.Write((const unsigned char*)U.data(), U.size());
+            hmacSha512u.Finalize((unsigned char*)U.data());
             for (j = 0; j < hashLen/sizeof(uint32_t); j++) T[j] ^= U[j]; // Ti = U1 ^ U2 ^ ... ^ Urounds
         }
 
         // dk = T1 || T2 || ... || Tdklen/hlen
-        memcpy((uint8_t *)dk + i*hashLen, T, (i*hashLen + hashLen <= dkLen) ? hashLen : dkLen % hashLen);
+        memcpy((uint8_t *)dk + i*hashLen, T.data(), (i*hashLen + hashLen <= dkLen) ? hashLen : dkLen % hashLen);
     }
-
-    memory_cleanse(s, sizeof(s));
-    memory_cleanse(U, sizeof(U));
-    memory_cleanse(T, sizeof(T));
 }

--- a/src/wallet/bip39mnemonic.cpp
+++ b/src/wallet/bip39mnemonic.cpp
@@ -121,13 +121,11 @@ int BIP39Mnemonic::PhraseIsValid(const char *phrase)
 
 void BIP39Mnemonic::DeriveKey(void *key64, const char *phrase, const char *passphrase)
 {
-    SecureString salt(strlen("mnemonic") + (passphrase ? strlen(passphrase) : 0) + 1, '\0');
-
     assert(key64 != NULL);
     assert(phrase != NULL);
 
     if (phrase) {
-        salt = "mnemonic";
+        SecureString salt = "mnemonic";
         if (passphrase) salt += passphrase;
         PBKDF2(key64, phrase, strlen(phrase), salt.c_str(), salt.size());
     }
@@ -182,7 +180,7 @@ void BIP39Mnemonic::PBKDF2(void *dk, const void *pw, size_t pwLen, const void *s
 
         // U1 = hmac_hash(pw, salt || be32(i))
         CHMAC_SHA512 hmacSha512s((const unsigned char*)pw, pwLen);
-        hmacSha512s.Write(s.data(), sizeof(s));
+        hmacSha512s.Write(s.data(), s.size());
         hmacSha512s.Finalize((unsigned char*)U.data());
         memcpy(T.data(), U.data(), U.size());
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1633,7 +1633,7 @@ bool CWallet::IsHDEnabled() const
 
 SecureString CWallet::GeneratePaperKey()
 {
-    const static size_t bufferSize = 128 / 8;
+    constexpr static size_t bufferSize = 128 / 8;
     unsigned char buffer[bufferSize] = {0};
 
     GetStrongRandBytes(buffer, bufferSize);
@@ -1642,14 +1642,12 @@ SecureString CWallet::GeneratePaperKey()
 
     size_t phraseLen = b39.Encode(NULL, 0, buffer, bufferSize);
 
-    char phrase[phraseLen];
-    memset(phrase, 0, phraseLen);
-    phraseLen = b39.Encode(phrase, phraseLen, buffer, bufferSize);
+    SecureVector<char> phrase(phraseLen, 0);
+    phraseLen = b39.Encode(phrase.data(), phraseLen, buffer, bufferSize);
 
-    SecureString phraseString(phrase);
+    SecureString phraseString(phrase.data());
 
     memory_cleanse(buffer, bufferSize);
-    memory_cleanse(phrase, phraseLen);
 
     return phraseString;
 }


### PR DESCRIPTION
Using heap-based **SecureString** and **SecureVector**  (std::vector<T, secure_allocator<T>>) in place of stack-based variable length arrays.