### PR TITLE
Re-introduce typeinfo header include

### DIFF
--- a/src/qt/restorewalletpage.cpp
+++ b/src/qt/restorewalletpage.cpp
@@ -1,5 +1,6 @@
 #include "restorewalletpage.h"
 #include "ui_restorewalletpage.h"
+#include <typeinfo>
 #include <QMessageBox>
 
 RestoreWalletPage::RestoreWalletPage(QWidget *parent) :


### PR DESCRIPTION
Re-introduced typeinfo header include
to mitigate build errors introduced with
recent changes in WalletRestorePage class.