### PR TITLE
Synchronization not done at 100%

### DIFF
--- a/src/qt/paicoingui.cpp
+++ b/src/qt/paicoingui.cpp
@@ -884,9 +884,8 @@ void PAIcoinGUI::continueFromPinRequest()
         appMenuBar->show();
         toolbar->show();
         tabGroup->setVisible(true);
-        progressBar->show();
-        statusBar()->show();
-        modalOverlay->showHide();
+        if (walletFrame && walletFrame->isOutOfSync())
+            modalOverlay->showHide();
 
         connect(walletFrame, SIGNAL(requestedSyncWarningInfo()), this, SLOT(showModalOverlay()));
         connect(labelBlocksIcon, SIGNAL(clicked(QPoint)), this, SLOT(showModalOverlay()));

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -44,6 +44,7 @@ public:
     bool handlePaymentRequest(const SendCoinsRecipient& recipient);
 
     void showOutOfSyncWarning(bool fShow);
+    bool isOutOfSync() { return bOutOfSync; }
 
 Q_SIGNALS:
     /** Notify that the user has requested more information about the out-of-sync warning */


### PR DESCRIPTION
Removed unnecessary UI initialization calls during PIN entry which caused modal overlay window to be displayed even when wallet is fully synced.