### PR TITLE
Qt: Gracefully terminate the application on error during startup

### DIFF
--- a/src/qt/paicoin.cpp
+++ b/src/qt/paicoin.cpp
@@ -327,10 +327,10 @@ void PAIcoinCore::initialize()
         qDebug() << __func__ << ": Running initialization in thread";
         bool firstRun = false;
         bool rv = AppInitMain(threadGroup, scheduler, firstRun);
-        if (firstRun) {
-            Q_EMIT initializeFirstRun();
-        } else {
+        if (!rv || !firstRun) {
             Q_EMIT initializeResult(rv);
+        } else {
+            Q_EMIT initializeFirstRun();
         }
     } catch (const std::exception& e) {
         handleRunawayException(&e);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1962,7 +1962,7 @@ bool static FlushStateToDisk(const CChainParams& chainparams, CValidationState &
             nLastWrite = nNow;
         }
         // Flush best chain related state. This can only be done if the blocks / block index write was also done.
-        if (fDoFullFlush) {
+        if (fDoFullFlush && !pcoinsTip->GetBestBlock().IsNull()) {
             // Typical Coin structures on disk are around 48 bytes in size.
             // Pushing a new one to the database can cause it to be written
             // twice (once in the log, and once in the tables). This is already

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -236,7 +236,7 @@ bool InitLoadWallet(bool& firstRun)
 
     for (const std::string& walletFile : gArgs.GetArgs("-wallet")) {
         CWallet * const pwallet = CWallet::CreateWalletFromFile(walletFile, firstRun);
-        if (!(pwallet || firstRun)) {
+        if (!pwallet) {
             return false;
         }
 


### PR DESCRIPTION
When the application encounters an error on startup (e.g. if using `-usehd=0`), it shows a popup with the error, but it doesn't actually stop and shows the startup screen instead. When the screen is closed afterwards, the application encounters a segmentation fault. This PR fixes it by:

1. Not moving on with initialization if result is not successful (irrespective of **firstRun** value).
2. Not flushing best chain state if `GetBestBlock()` is null (merged from Bitcoin repo).
