### PR TITLE
Fix crash bug with duplicate inputs within a transaction (merge from bitcoin)

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2835,7 +2835,7 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
 
     // Check transactions
     for (const auto& tx : block.vtx)
-        if (!CheckTransaction(*tx, state, false))
+        if (!CheckTransaction(*tx, state, true))
             return state.Invalid(false, state.GetRejectCode(), state.GetRejectReason(),
                                  strprintf("Transaction check failed (tx hash %s) %s", tx->GetHash().ToString(), state.GetDebugMessage()));
 


### PR DESCRIPTION
Merged the following PR from bitcoin repository: https://github.com/bitcoin/bitcoin/pull/14247 .
Merged the actual fix only, the functional test is not yet merged in:

bitcoin:
Merge #14247: Fix crash bug with duplicate inputs within a transaction

b8f801964f59586508ea8da6cf3decd76bc0e571 Fix crash bug with duplicate inputs within a transaction (Suhas Daftuar)

Pull request description:

Tree-SHA512: 8c7ea34c7fa44188d86c04a690a7cbf8e9deda71ab1f7ca6d11de1f2abb3dd7222627071f86d0d39689a8b302ba9af142f0202466a67e30cd54aed3a08d4eb14