### PR TITLE
Prevent investor multisig in normal transaction funding

### DIFF
--- a/src/wallet/investor.cpp
+++ b/src/wallet/investor.cpp
@@ -553,6 +553,22 @@ bool Investor::AddressIsMyMultisig(std::string& address)
     return false;
 }
 
+bool Investor::ScriptIsMyMultisig(const CScript& script)
+{
+    if (script.size() == 23
+        && script[0] == OP_HASH160
+        && script[1] == 20
+        && script[22] == OP_EQUAL) {
+
+        uint160 hash160;
+        memcpy(&hash160, &script[2], 20);
+
+        return Hash160IsMyMultisig(hash160);
+    }
+
+    return false;
+}
+
 bool Investor::Hash160IsMyMultisig(const uint160& hash160)
 {
     if (hash160.size() == 0) { return false; }

--- a/src/wallet/investor.h
+++ b/src/wallet/investor.h
@@ -61,6 +61,9 @@ public:
     /* Returns true if the address is one of the investor's multisig addresses */
     bool AddressIsMyMultisig(std::string& address);
 
+    /* Returns true if the script is paying to one of the investor's multisig addresses */
+    bool ScriptIsMyMultisig(const CScript& script);
+
     /* Returns true if the Hash160 is one of the investor's multisig keys */
     bool Hash160IsMyMultisig(const uint160& hash160);
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2630,6 +2630,10 @@ void CWallet::AvailableCoins(std::vector<COutput> &vCoins, bool fOnlySafe, const
                 if (IsSpent(wtxid, i))
                     continue;
 
+                // do not allow the investor multisig addresses to be referred directly into funding transactions
+                if (Investor::GetInstance().ScriptIsMyMultisig(pcoin->tx->vout[i].scriptPubKey))
+                    continue;
+
                 isminetype mine = IsMine(pcoin->tx->vout[i]);
 
                 if (mine == ISMINE_NO) {


### PR DESCRIPTION
Added investor multisig address filtration for available coins selection when funding normal transactions.