### PR TITLE
rpc-refactor6: Refactored RPC misc code for safety and readability

### DIFF
--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1098,7 +1098,7 @@ UniValue sendmany(const JSONRPCRequest& request)
 }
 
 // Defined in rpc/misc.cpp
-extern CScript _createmultisig_redeemScript(CWallet * const pwallet, const UniValue& params);
+extern CScript _createmultisig_redeemScript(const CWallet * const pwallet, const UniValue& params);
 
 UniValue addmultisigaddress(const JSONRPCRequest& request)
 {


### PR DESCRIPTION
Refactored RPC misc code with the following improvements:

- const-correctness
- use of C++11's **auto** to limit unwanted type casts, improve type safety and improve readability for long types
- using C++11's **{}-init** syntax for type safety and improved readability