### PR TITLE
net: remove now-superfluous numeric resolve

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1919,11 +1919,9 @@ void CConnman::ThreadOpenAddedConnections()
                     // the addednodeinfo state might change.
                     break;
                 }
-                // If strAddedNode is an IP/port, decode it immediately, so
-                // OpenNetworkConnection can detect existing connections to that IP/port.
                 tried = true;
-                CService service(LookupNumeric(info.strAddedNode.c_str(), Params().GetDefaultPort()));
-                OpenNetworkConnection(CAddress(service, NODE_NONE), false, &grant, info.strAddedNode.c_str(), false, false, true);
+                CAddress addr(CService(), NODE_NONE);
+                OpenNetworkConnection(addr, false, &grant, info.strAddedNode.c_str(), false, false, true);
                 if (!interruptNet.sleep_for(std::chrono::milliseconds(500)))
                     return;
             }


### PR DESCRIPTION
This was added in order to help OpenNetworkConnection avoid creating a
connection that it would end up aborting. It was necessary because resolving
was done as part of the connection process.

Now that resolving is separated from connecting, this case is detected before
the connection is attempted.

Signed-off-by: Florin Balate <florin.balate@upandrunningsoftware.com>