### PR TITLE
Remove some unused functions and methods

### DIFF
--- a/src/hash.h
+++ b/src/hash.h
@@ -88,20 +88,6 @@ inline uint256 Hash(const T1 p1begin, const T1 p1end,
     return result;
 }
 
-/** Compute the 256-bit hash of the concatenation of three objects. */
-template<typename T1, typename T2, typename T3>
-inline uint256 Hash(const T1 p1begin, const T1 p1end,
-                    const T2 p2begin, const T2 p2end,
-                    const T3 p3begin, const T3 p3end) {
-    static const unsigned char pblank[1] = {};
-    uint256 result;
-    CHash256().Write(p1begin == p1end ? pblank : (const unsigned char*)&p1begin[0], (p1end - p1begin) * sizeof(p1begin[0]))
-              .Write(p2begin == p2end ? pblank : (const unsigned char*)&p2begin[0], (p2end - p2begin) * sizeof(p2begin[0]))
-              .Write(p3begin == p3end ? pblank : (const unsigned char*)&p3begin[0], (p3end - p3begin) * sizeof(p3begin[0]))
-              .Finalize((unsigned char*)&result);
-    return result;
-}
-
 /** Compute the 160-bit hash an object. */
 template<typename T1>
 inline uint160 Hash160(const T1 pbegin, const T1 pend)

--- a/src/key.h
+++ b/src/key.h
@@ -56,11 +56,6 @@ public:
         keydata.resize(32);
     }
 
-    //! Destructor (again necessary because of memlocking).
-    ~CKey()
-    {
-    }
-
     friend bool operator==(const CKey& a, const CKey& b)
     {
         return a.fCompressed == b.fCompressed &&

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -111,7 +111,6 @@ public:
 class uint160 : public base_blob<160> {
 public:
     uint160() {}
-    explicit uint160(const base_blob<160>& b) : base_blob<160>(b) {}
     explicit uint160(const std::vector<unsigned char>& vch) : base_blob<160>(vch) {}
 };
 
@@ -123,7 +122,6 @@ public:
 class uint256 : public base_blob<256> {
 public:
     uint256() {}
-    explicit uint256(const base_blob<256>& b) : base_blob<256>(b) {}
     explicit uint256(const std::vector<unsigned char>& vch) : base_blob<256>(vch) {}
 
     /** A cheap hash function that just returns 64 bits from the result, it can be


### PR DESCRIPTION
In the case of CKey's destructor, it seems to have been an oversight in
f4d1fc259 not to delete it. At this point, it results in the move
constructors/assignment operators for CKey being deleted, which may have
a performance impact.

Signed-off-by: Florin Balate <florin.balate@upandrunningsoftware.com>