### PR TITLE
Convert C-style (void) parameter lists to C++ style () (merge from bitcoin)

### DIFF
--- a/src/bench/bench.cpp
+++ b/src/bench/bench.cpp
@@ -15,7 +15,7 @@ benchmark::BenchRunner::BenchmarkMap &benchmark::BenchRunner::benchmarks() {
     return benchmarks_map;
 }
 
-static double gettimedouble(void) {
+static double gettimedouble() {
     struct timeval tv;
     gettimeofday(&tv, nullptr);
     return tv.tv_usec * 0.000001 + tv.tv_sec;

--- a/src/bench/perf.cpp
+++ b/src/bench/perf.cpp
@@ -9,8 +9,8 @@
 /* These architectures support querying the cycle counter
  * from user space, no need for any syscall overhead.
  */
-void perf_init(void) { }
-void perf_fini(void) { }
+void perf_init() { }
+void perf_fini() { }
 
 #elif defined(__linux__)
 
@@ -21,21 +21,21 @@ void perf_fini(void) { }
 static int fd = -1;
 static struct perf_event_attr attr;
 
-void perf_init(void)
+void perf_init()
 {
     attr.type = PERF_TYPE_HARDWARE;
     attr.config = PERF_COUNT_HW_CPU_CYCLES;
     fd = syscall(__NR_perf_event_open, &attr, 0, -1, -1, 0);
 }
 
-void perf_fini(void)
+void perf_fini()
 {
     if (fd != -1) {
         close(fd);
     }
 }
 
-uint64_t perf_cpucycles(void)
+uint64_t perf_cpucycles()
 {
     uint64_t result = 0;
     if (fd == -1 || read(fd, &result, sizeof(result)) < (ssize_t)sizeof(result)) {
@@ -46,8 +46,8 @@ uint64_t perf_cpucycles(void)
 
 #else /* Unhandled platform */
 
-void perf_init(void) { }
-void perf_fini(void) { }
-uint64_t perf_cpucycles(void) { return 0; }
+void perf_init() { }
+void perf_fini() { }
+uint64_t perf_cpucycles() { return 0; }
 
 #endif

--- a/src/bench/perf.h
+++ b/src/bench/perf.h
@@ -10,7 +10,7 @@
 
 #if defined(__i386__)
 
-static inline uint64_t perf_cpucycles(void)
+static inline uint64_t perf_cpucycles()
 {
     uint64_t x;
     __asm__ volatile (".byte 0x0f, 0x31" : "=A" (x));
@@ -19,7 +19,7 @@ static inline uint64_t perf_cpucycles(void)
 
 #elif defined(__x86_64__)
 
-static inline uint64_t perf_cpucycles(void)
+static inline uint64_t perf_cpucycles()
 {
     uint32_t hi, lo;
     __asm__ __volatile__ ("rdtsc" : "=a"(lo), "=d"(hi));
@@ -27,11 +27,11 @@ static inline uint64_t perf_cpucycles(void)
 }
 #else
 
-uint64_t perf_cpucycles(void);
+uint64_t perf_cpucycles();
 
 #endif
 
-void perf_init(void);
-void perf_fini(void);
+void perf_init();
+void perf_fini();
 
 #endif // H_PERF

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -31,7 +31,7 @@ static const char* const WWW_AUTH_HEADER_DATA = "Basic realm=\"jsonrpc\"";
 class HTTPRPCTimer : public RPCTimerBase
 {
 public:
-    HTTPRPCTimer(struct event_base* eventBase, std::function<void(void)>& func, int64_t millis) :
+    HTTPRPCTimer(struct event_base* eventBase, std::function<void()>& func, int64_t millis) :
         ev(eventBase, false, func)
     {
         struct timeval tv;
@@ -53,7 +53,7 @@ public:
     {
         return "HTTP";
     }
-    RPCTimerBase* NewTimer(std::function<void(void)>& func, int64_t millis) override
+    RPCTimerBase* NewTimer(std::function<void()>& func, int64_t millis) override
     {
         return new HTTPRPCTimer(base, func, millis);
     }

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -518,7 +518,7 @@ static void httpevent_callback_fn(evutil_socket_t, short, void* data)
         delete self;
 }
 
-HTTPEvent::HTTPEvent(struct event_base* base, bool _deleteWhenTriggered, const std::function<void(void)>& _handler):
+HTTPEvent::HTTPEvent(struct event_base* base, bool _deleteWhenTriggered, const std::function<void()>& _handler):
     deleteWhenTriggered(_deleteWhenTriggered), handler(_handler)
 {
     ev = event_new(base, -1, 0, httpevent_callback_fn, this);

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -134,7 +134,7 @@ public:
      * deleteWhenTriggered deletes this event object after the event is triggered (and the handler called)
      * handler is the handler to call when the event is triggered.
      */
-    HTTPEvent(struct event_base* base, bool deleteWhenTriggered, const std::function<void(void)>& handler);
+    HTTPEvent(struct event_base* base, bool deleteWhenTriggered, const std::function<void()>& handler);
     ~HTTPEvent();
 
     /** Trigger the event. If tv is 0, trigger it immediately. Otherwise trigger it after
@@ -143,7 +143,7 @@ public:
     void trigger(struct timeval* tv);
 
     bool deleteWhenTriggered;
-    std::function<void(void)> handler;
+    std::function<void()> handler;
 private:
     struct event* ev;
 };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -690,7 +690,7 @@ void ThreadImport(std::vector<fs::path> vImportFiles)
  *  Ensure that PAIcoin is running in a usable environment with all
  *  necessary library support.
  */
-bool InitSanityCheck(void)
+static bool InitSanityCheck()
 {
     if(!ECC_InitSanityCheck()) {
         InitError("Elliptic curve cryptography sanity check failure. Aborting.");

--- a/src/key.h
+++ b/src/key.h
@@ -180,12 +180,12 @@ struct CExtKey {
 };
 
 /** Initialize the elliptic curve support. May not be called twice without calling ECC_Stop first. */
-void ECC_Start(void);
+void ECC_Start();
 
 /** Deinitialize the elliptic curve support. No-op if ECC_Start wasn't called first. */
-void ECC_Stop(void);
+void ECC_Stop();
 
 /** Check that required EC support is available at runtime. */
-bool ECC_InitSanityCheck(void);
+bool ECC_InitSanityCheck();
 
 #endif // PAICOIN_KEY_H

--- a/src/qt/macnotificationhandler.h
+++ b/src/qt/macnotificationhandler.h
@@ -22,7 +22,7 @@ public:
     void sendAppleScript(const QString &script);
 
     /** check if OS can handle UserNotifications */
-    bool hasUserNotificationCenterSupport(void);
+    bool hasUserNotificationCenterSupport();
     static MacNotificationHandler *instance();
 };
 

--- a/src/qt/paicoin.cpp
+++ b/src/qt/paicoin.cpp
@@ -588,7 +588,7 @@ int main(int argc, char *argv[])
     //   Need to pass name here as CAmount is a typedef (see http://qt-project.org/doc/qt-5/qmetatype.html#qRegisterMetaType)
     //   IMPORTANT if it is no longer a typedef use the normal variant above
     qRegisterMetaType< CAmount >("CAmount");
-    qRegisterMetaType< std::function<void(void)> >("std::function<void(void)>");
+    qRegisterMetaType< std::function<void()> >("std::function<void()>");
 
     /// 3. Application identification
     // must be set before OptionsModel is initialized or translations are loaded,

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -97,7 +97,7 @@ class QtRPCTimerBase: public QObject, public RPCTimerBase
 {
     Q_OBJECT
 public:
-    QtRPCTimerBase(std::function<void(void)>& _func, int64_t millis):
+    QtRPCTimerBase(std::function<void()>& _func, int64_t millis):
         func(_func)
     {
         timer.setSingleShot(true);
@@ -109,7 +109,7 @@ private Q_SLOTS:
     void timeout() { func(); }
 private:
     QTimer timer;
-    std::function<void(void)> func;
+    std::function<void()> func;
 };
 
 class QtRPCTimerInterface: public RPCTimerInterface
@@ -117,7 +117,7 @@ class QtRPCTimerInterface: public RPCTimerInterface
 public:
     ~QtRPCTimerInterface() {}
     const char *Name() const { return "Qt"; }
-    RPCTimerBase* NewTimer(std::function<void(void)>& func, int64_t millis)
+    RPCTimerBase* NewTimer(std::function<void()>& func, int64_t millis)
     {
         return new QtRPCTimerBase(func, millis);
     }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -537,7 +537,7 @@ void RPCUnsetTimerInterface(RPCTimerInterface *iface)
         timerInterface = nullptr;
 }
 
-void RPCRunLater(const std::string& name, std::function<void(void)> func, int64_t nSeconds)
+void RPCRunLater(const std::string& name, std::function<void()> func, int64_t nSeconds)
 {
     if (!timerInterface)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "No timer handler registered for RPC");

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -109,7 +109,7 @@ public:
      * This is needed to cope with the case in which there is no HTTP server, but
      * only GUI RPC console, and to break the dependency of pcserver on httprpc.
      */
-    virtual RPCTimerBase* NewTimer(std::function<void(void)>& func, int64_t millis) = 0;
+    virtual RPCTimerBase* NewTimer(std::function<void()>& func, int64_t millis) = 0;
 };
 
 /** Set the factory function for timers */
@@ -123,7 +123,7 @@ void RPCUnsetTimerInterface(RPCTimerInterface *iface);
  * Run func nSeconds from now.
  * Overrides previous timer <name> (if any).
  */
-void RPCRunLater(const std::string& name, std::function<void(void)> func, int64_t nSeconds);
+void RPCRunLater(const std::string& name, std::function<void()> func, int64_t nSeconds);
 
 typedef UniValue(*rpcfn_type)(const JSONRPCRequest& jsonRequest);
 

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -159,7 +159,7 @@ void SingleThreadedSchedulerClient::MaybeScheduleProcessQueue() {
 }
 
 void SingleThreadedSchedulerClient::ProcessQueue() {
-    std::function<void (void)> callback;
+    std::function<void ()> callback;
     {
         LOCK(m_cs_callbacks_pending);
         if (m_are_callbacks_running) return;
@@ -187,7 +187,7 @@ void SingleThreadedSchedulerClient::ProcessQueue() {
     callback();
 }
 
-void SingleThreadedSchedulerClient::AddToProcessQueue(std::function<void (void)> func) {
+void SingleThreadedSchedulerClient::AddToProcessQueue(std::function<void ()> func) {
     assert(m_pscheduler);
 
     {

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -40,7 +40,7 @@ public:
     CScheduler();
     ~CScheduler();
 
-    typedef std::function<void(void)> Function;
+    typedef std::function<void()> Function;
 
     // Call func at/after time t
     void schedule(Function f, boost::chrono::system_clock::time_point t=boost::chrono::system_clock::now());
@@ -95,7 +95,7 @@ private:
     CScheduler *m_pscheduler;
 
     CCriticalSection m_cs_callbacks_pending;
-    std::list<std::function<void (void)>> m_callbacks_pending;
+    std::list<std::function<void ()>> m_callbacks_pending;
     bool m_are_callbacks_running = false;
 
     void MaybeScheduleProcessQueue();
@@ -103,7 +103,7 @@ private:
 
 public:
     explicit SingleThreadedSchedulerClient(CScheduler *pschedulerIn) : m_pscheduler(pschedulerIn) {}
-    void AddToProcessQueue(std::function<void (void)> func);
+    void AddToProcessQueue(std::function<void ()> func);
 
     // Processes all remaining queue members on the calling thread, blocking until queue is empty
     // Must be called after the CScheduler has no remaining processing threads!

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -200,7 +200,7 @@ void TestChaCha20(const std::string &hexkey, uint64_t nonce, uint64_t seek, cons
     BOOST_CHECK(out == outres);
 }
 
-std::string LongTestString(void) {
+static std::string LongTestString() {
     std::string ret;
     for (int i=0; i<200000; i++) {
         ret += (unsigned char)(i);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -4306,7 +4306,7 @@ int VersionBitsTipStateSinceHeight(const Consensus::Params& params, Consensus::D
 
 static const uint64_t MEMPOOL_DUMP_VERSION = 1;
 
-bool LoadMempool(void)
+bool LoadMempool()
 {
     const CChainParams& chainparams = Params();
     int64_t nExpiryTimeout = gArgs.GetArg("-mempoolexpiry", DEFAULT_MEMPOOL_EXPIRY) * 60 * 60;
@@ -4373,7 +4373,7 @@ bool LoadMempool(void)
     return true;
 }
 
-bool DumpMempool(void)
+bool DumpMempool()
 {
     int64_t start = GetTimeMicros();
 

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -64,7 +64,7 @@ static void add_coin(const CAmount& nValue, int nAge = 6*24, bool fIsFromMe = fa
     wtxn.emplace_back(std::move(wtx));
 }
 
-static void empty_wallet(void)
+static void empty_wallet()
 {
     vCoins.clear();
     wtxn.clear();


### PR DESCRIPTION
Merge from bitcoin: https://github.com/bitcoin/bitcoin/pull/14214

Convert C-style (void) parameter lists to C++ style ()

3ccfa34b32 convert C-style (void) parameter lists to C++ style () (Arvid Norberg)

Pull request description:

  In C, an empty parameter list, `()`, means the function takes any arguments, and `(void)` means the function does not take any parameters.
  In C++, an empty parameter list means the function does not take any parameters.

  So, C++ still supports `(void)` parameter lists with the same semantics, why change to `()`?

  1. removing the redundant `void` improves signal-to-noise ratio of the code
  2. using `(void)` exposes a rare inconsistency in that a template taking a template `(T)` parameter list, cannot be instantiated with `T=void`

Additionally, a few more occurrences in paicoin have been converted apart from the ones from the above bitcoin PR.

Signed-off-by: dartdart26 <29689712+dartdart26@users.noreply.github.com>