### PR TITLE
Update importprivkey named args documentation

### DIFF
--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -81,10 +81,10 @@ UniValue importprivkey(const JSONRPCRequest& request)
 
     if (request.fHelp || request.params.size() < 1 || request.params.size() > 3)
         throw std::runtime_error{
-            "importprivkey \"paicoinprivkey\" ( \"label\" ) ( rescan )\n"
+            "importprivkey \"privkey\" ( \"label\" ) ( rescan )\n"
             "\nAdds a private key (as returned by dumpprivkey) to your wallet.\n"
             "\nArguments:\n"
-            "1. \"paicoinprivkey\"   (string, required) The private key (see dumpprivkey)\n"
+            "1. \"privkey\"          (string, required) The private key (see dumpprivkey)\n"
             "2. \"label\"            (string, optional, default=\"\") An optional label\n"
             "3. rescan               (boolean, optional, default=true) Rescan the wallet for transactions\n"
             "\nNote: This call can take minutes to complete if rescan is true.\n"

--- a/test/functional/importprunedfunds.py
+++ b/test/functional/importprunedfunds.py
@@ -78,7 +78,7 @@ class ImportPrunedFundsTest(PAIcoinTestFramework):
         assert_equal(balance2, Decimal('0.05'))
 
         #Import with private key with no rescan
-        self.nodes[1].importprivkey(address3_privkey, "add3", False)
+        self.nodes[1].importprivkey(privkey=address3_privkey, label="add3", rescan=False)
         self.nodes[1].importprunedfunds(rawtxn3, proof3)
         balance3 = self.nodes[1].getbalance("add3", 0, False)
         assert_equal(balance3, Decimal('0.025'))


### PR DESCRIPTION
Fixes #11462. Updated documentation for importprivkey function to use the correct name for the first argument.
Also updates a call to importprivkey to use named args in functional test.

Signed-off-by: Florin Balate <florin.balate@upandrunningsoftware.com>