### PR TITLE
Specifically test wallet's getbalance and getunconfirmedbalance RPCs

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -123,6 +123,7 @@ BASE_SCRIPTS= [
     'resendwallettransactions.py',
     'minchainwork.py',
     'rpc_help.py',
+    'wallet_balance.py'
 ]
 
 EXTENDED_SCRIPTS = [

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the wallet balance RPC methods."""
+from decimal import Decimal
+import time
+
+from test_framework.test_framework import PAIcoinTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_raises_jsonrpc,
+)
+
+RANDOM_COINBASE_ADDRESS = 'MeLRHX4aF9Yrkpwzg2xegnAWVyGQBcDwML'
+
+def create_transactions(node, address, amt, fees):
+    # Create and sign raw transactions from node to address for amt.
+    # Creates a transaction for each fee and returns an array
+    # of the raw transactions.
+    utxos = node.listunspent(0)
+
+    # Create transactions
+    inputs = []
+    ins_total = 0
+    for utxo in utxos:
+        inputs.append({"txid": utxo["txid"], "vout": utxo["vout"]})
+        ins_total += utxo['amount']
+        if ins_total > amt:
+            break
+
+    txs = []
+    for fee in fees:
+        outputs = {address: amt, node.getrawchangeaddress(): ins_total - amt - fee}
+        raw_tx = node.createrawtransaction(inputs, outputs, 0, True)
+        raw_tx = node.signrawtransaction(raw_tx)
+        txs.append(raw_tx)
+
+    return txs
+
+class WalletTest(PAIcoinTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 2
+        self.setup_clean_chain = True
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        # Check that nodes don't own any UTXOs
+        assert_equal(len(self.nodes[0].listunspent()), 0)
+        assert_equal(len(self.nodes[1].listunspent()), 0)
+
+        self.log.info("Mining one block for each node")
+
+        self.nodes[0].generate(1)
+        self.sync_all()
+        self.nodes[1].generate(1)
+        self.nodes[1].generatetoaddress(100, RANDOM_COINBASE_ADDRESS)
+        self.sync_all()
+
+        assert_equal(self.nodes[0].getbalance(), 1500)
+        assert_equal(self.nodes[1].getbalance(), 1500)
+
+        self.log.info("Test getbalance with different arguments")
+        assert_equal(self.nodes[0].getbalance("*"), 1500)
+        assert_equal(self.nodes[0].getbalance("*", 1), 1500)
+        assert_equal(self.nodes[0].getbalance("*", 1, True), 1500)
+        assert_raises_jsonrpc(-8, "getbalance minconf option is only currently supported if an account is specified", self.nodes[0].getbalance, minconf='1')
+
+        # Send 1490 BTC from 0 to 1 and 1510 BTC from 1 to 0.
+        txs = create_transactions(self.nodes[0], self.nodes[1].getnewaddress(), 1490, [Decimal('0.01')])
+        self.nodes[0].sendrawtransaction(txs[0]['hex'])
+        self.nodes[1].sendrawtransaction(txs[0]['hex'])  # sending on both nodes is faster than waiting for propagation
+
+        self.sync_all()
+        txs = create_transactions(self.nodes[1], self.nodes[0].getnewaddress(), 1510, [Decimal('0.01'), Decimal('0.02')])
+        self.nodes[1].sendrawtransaction(txs[0]['hex'])
+        self.nodes[0].sendrawtransaction(txs[0]['hex'])  # sending on both nodes is faster than waiting for propagation
+        self.sync_all()
+
+        # NOTE: Skip below test until newer getbalance implementation that handles '*' as a dummy first argument gets merged in
+        # First argument of getbalance must be set to "*"
+        # assert_raises_jsonrpc(-32, "dummy first argument must be excluded or set to \"*\"", self.nodes[1].getbalance, "")
+
+        self.log.info("Test getbalance and getunconfirmedbalance with unconfirmed inputs")
+
+        # getbalance without any arguments includes unconfirmed transactions, but not untrusted transactions
+        assert_equal(self.nodes[0].getbalance(), Decimal('9.99'))  # change from node 0's send
+        assert_equal(self.nodes[1].getbalance(), Decimal('1479.99'))  # change from node 1's send
+
+        # NOTE: Skip below test (minconf=0) until newer getbalance implementation that doesn't use CWallet::GetLegacyBalance() gets merged in
+        # Same with minconf=0
+        # assert_equal(self.nodes[0].getbalance(account='*', minconf=0), Decimal('1519.99'))
+        # assert_equal(self.nodes[1].getbalance(account='*', minconf=0), Decimal('1479.99'))
+
+        # NOTE: Skip below test (minconf=0) until newer getbalance implementation that doesn't use CWallet::GetLegacyBalance() gets merged in
+        # getbalance with a minconf incorrectly excludes coins that have been spent more recently than the minconf blocks ago
+        # TODO: fix getbalance tracking of coin spentness depth
+        # assert_equal(self.nodes[0].getbalance(account='*', minconf=1), Decimal('9.99'))
+        # assert_equal(self.nodes[1].getbalance(account='*', minconf=1), Decimal('-10.01'))
+
+        # getunconfirmedbalance
+        assert_equal(self.nodes[0].getunconfirmedbalance(), Decimal('1510'))  # output of node 1's spend
+        assert_equal(self.nodes[1].getunconfirmedbalance(), Decimal('0'))  # Doesn't include output of node 0's send since it was spent
+
+        # Node 1 bumps the transaction fee and resends
+        self.nodes[1].sendrawtransaction(txs[1]['hex'])
+        self.sync_all()
+
+        self.log.info("Test getbalance and getunconfirmedbalance with conflicted unconfirmed inputs")
+
+        assert_equal(self.nodes[0].getwalletinfo()["unconfirmed_balance"], Decimal('1510'))  # output of node 1's send
+        assert_equal(self.nodes[0].getunconfirmedbalance(), Decimal('1510'))
+        assert_equal(self.nodes[1].getwalletinfo()["unconfirmed_balance"], Decimal('0'))  # Doesn't include output of node 0's send since it was spent
+        assert_equal(self.nodes[1].getunconfirmedbalance(), Decimal('0'))
+
+        self.nodes[1].generatetoaddress(1, RANDOM_COINBASE_ADDRESS)
+        self.sync_all()
+
+        # balances are correct after the transactions are confirmed
+        assert_equal(self.nodes[0].getbalance(), Decimal('1519.99'))  # node 1's send plus change from node 0's send
+        assert_equal(self.nodes[1].getbalance(), Decimal('1479.98'))  # change from node 0's send
+
+        # Send total balance away from node 1
+        txs = create_transactions(self.nodes[1], self.nodes[0].getnewaddress(), Decimal('1479.97'), [Decimal('0.01')])
+        self.nodes[1].sendrawtransaction(txs[0]['hex'])
+        self.nodes[1].generatetoaddress(2, RANDOM_COINBASE_ADDRESS)
+        self.sync_all()
+
+        # NOTE: Remove deprecated account='*' when a newer getbalance implementation that handles '*' as a dummy first argument gets merged in
+        # getbalance with a minconf incorrectly excludes coins that have been spent more recently than the minconf blocks ago
+        # TODO: fix getbalance tracking of coin spentness depth
+        # getbalance with minconf=3 should still show the old balance
+        assert_equal(self.nodes[1].getbalance(account='*', minconf=3), Decimal('0'))
+
+        # getbalance with minconf=2 will show the new balance.
+        assert_equal(self.nodes[1].getbalance(account='*', minconf=2), Decimal('0'))
+
+if __name__ == '__main__':
+    WalletTest().main()


### PR DESCRIPTION
Merge bitcoin PR: https://github.com/bitcoin/bitcoin/pull/14845

> Adds a test specifically to test the wallet's getbalance and getunconfirmedbalance RPCs.

Changes were made to make it work with paicoin's implementation of getbalance.