### PR TITLE
Issue #35 Update block header and validation to support staking

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -218,6 +218,10 @@ public:
     uint32_t nTime;
     uint32_t nBits;
     uint32_t nNonce;
+    int64_t nStakeDifficulty;
+    uint32_t nVoteBits;
+    uint32_t nTicketPoolSize;
+    std::array<char,6> ticketLotteryState;
 
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     int32_t nSequenceId;
@@ -251,6 +255,10 @@ public:
         nTime          = 0;
         nBits          = 0;
         nNonce         = 0;
+        nStakeDifficulty = 0;
+        nVoteBits      = 0;
+        nTicketPoolSize = 0;
+        std::fill(ticketLotteryState.begin(), ticketLotteryState.end(), 0);
     }
 
     CBlockIndex()
@@ -267,6 +275,10 @@ public:
         nTime          = block.nTime;
         nBits          = block.nBits;
         nNonce         = block.nNonce;
+        nStakeDifficulty = block.nStakeDifficulty;
+        nVoteBits      = block.nVoteBits;
+        nTicketPoolSize = block.nTicketPoolSize;
+        ticketLotteryState = block.ticketLotteryState;
     }
 
     CDiskBlockPos GetBlockPos() const {
@@ -306,6 +318,10 @@ public:
         block.nTime          = nTime;
         block.nBits          = nBits;
         block.nNonce         = nNonce;
+        block.nStakeDifficulty = nStakeDifficulty;
+        block.nVoteBits      = nVoteBits;
+        block.nTicketPoolSize = nTicketPoolSize;
+        block.ticketLotteryState = ticketLotteryState;
         return block;
     }
 
@@ -436,6 +452,10 @@ public:
         block.nTime           = nTime;
         block.nBits           = nBits;
         block.nNonce          = nNonce;
+        block.nStakeDifficulty = nStakeDifficulty;
+        block.nVoteBits       = nVoteBits;
+        block.nTicketPoolSize = nTicketPoolSize;
+        block.ticketLotteryState = ticketLotteryState;
         return block.GetHash();
     }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -73,10 +73,13 @@ static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesi
     CBlock genesis;
     genesis.nTime    = nTime;
     genesis.nBits    = nBits;
+    genesis.nStakeDifficulty = 0;
+    genesis.nVoteBits = 0;
+    genesis.nTicketPoolSize = 0;
+    std::fill(genesis.ticketLotteryState.begin(), genesis.ticketLotteryState.end(), 0);
     genesis.nNonce   = nNonce;
     genesis.nVersion = nVersion;
     genesis.vtx.push_back(MakeTransactionRef(std::move(txNew)));
-    genesis.vstx.clear();
     genesis.hashPrevBlock.SetNull();
     genesis.hashMerkleRoot = BlockMerkleRoot(genesis);
     return genesis;

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -59,6 +59,11 @@ unsigned int GetP2SHSigOpCount(const CTransaction& tx, const CCoinsViewCache& ma
 int64_t GetTransactionSigOpCost(const CTransaction& tx, const CCoinsViewCache& inputs, int flags);
 
 /**
+ * Check if transaction is expired with respect to given block height. Consensus critical.
+ */
+bool IsExpiredTx(const CTransaction &tx, int nBlockHeight);
+
+/**
  * Check if transaction is final and can be included in a block with the
  * specified height and time. Consensus critical.
  */

--- a/src/core_write.cpp
+++ b/src/core_write.cpp
@@ -163,6 +163,7 @@ void TxToUniv(const CTransaction& tx, const uint256& hashBlock, UniValue& entry,
     entry.pushKV("size", (int)::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION));
     entry.pushKV("vsize", (GetTransactionWeight(tx) + WITNESS_SCALE_FACTOR - 1) / WITNESS_SCALE_FACTOR);
     entry.pushKV("locktime", (int64_t)tx.nLockTime);
+    entry.pushKV("expiry", (int64_t)tx.nExpiry);
 
     UniValue vin(UniValue::VARR);
     for (unsigned int i = 0; i < tx.vin.size(); i++) {

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -19,13 +19,19 @@ uint256 CBlockHeader::GetHash() const
 
 std::string CBlock::ToString() const
 {
+    std::string ticketLotteryStateString;
+    for (auto c : ticketLotteryState)
+        ticketLotteryStateString += std::to_string((int)c) + " ";
+
     std::stringstream s;
-    s << strprintf("CBlock(hash=%s, ver=0x%08x, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
+    s << strprintf("CBlock(hash=%s, ver=0x%08x, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, "
+                   "nStakeDifficulty=%s, nVoteBits=%08x, nTicketPoolSize=%u, ticketLotteryState=%s, vtx=%u)\n",
         GetHash().ToString(),
         nVersion,
         hashPrevBlock.ToString(),
         hashMerkleRoot.ToString(),
         nTime, nBits, nNonce,
+        std::to_string(nStakeDifficulty), nVoteBits, nTicketPoolSize, ticketLotteryStateString,
         vtx.size());
     for (const auto& tx : vtx) {
         s << "  " << tx->ToString() << "\n";

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -27,6 +27,10 @@ public:
     uint32_t nTime;
     uint32_t nBits;
     uint32_t nNonce;
+    int64_t nStakeDifficulty;
+    uint32_t nVoteBits;
+    uint32_t nTicketPoolSize;
+    std::array<char,6> ticketLotteryState;
 
     CBlockHeader()
     {
@@ -53,6 +57,10 @@ public:
         nTime = 0;
         nBits = 0;
         nNonce = 0;
+        nStakeDifficulty = 0;
+        nVoteBits = 0;
+        nTicketPoolSize = 0;
+        std::fill(ticketLotteryState.begin(), ticketLotteryState.end(), 0);
     }
 
     bool IsNull() const
@@ -74,8 +82,6 @@ class CBlock : public CBlockHeader
 public:
     // network and disk
     std::vector<CTransactionRef> vtx;
-    // stake transactions
-    std::vector<CTransactionRef> vstx;
 
     // memory only
     mutable bool fChecked;
@@ -97,15 +103,12 @@ public:
     inline void SerializationOp(Stream& s, Operation ser_action) {
         READWRITE(*static_cast<CBlockHeader*>(this));
         READWRITE(vtx);
-        if (s.GetVersion() > 70015)
-            READWRITE(vstx);
     }
 
     void SetNull()
     {
         CBlockHeader::SetNull();
         vtx.clear();
-        vstx.clear();
         fChecked = false;
     }
 
@@ -118,6 +121,10 @@ public:
         block.nTime          = nTime;
         block.nBits          = nBits;
         block.nNonce         = nNonce;
+        block.nVoteBits      = nVoteBits;
+        block.nStakeDifficulty = nStakeDifficulty;
+        block.nTicketPoolSize = nTicketPoolSize;
+        block.ticketLotteryState = ticketLotteryState;
         return block;
     }
 

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -54,8 +54,8 @@ std::string CTxOut::ToString() const
     return strprintf("CTxOut(nValue=%d.%08d, scriptPubKey=%s)", nValue / COIN, nValue % COIN, HexStr(scriptPubKey).substr(0, 30));
 }
 
-CMutableTransaction::CMutableTransaction() : nVersion(CTransaction::CURRENT_VERSION), nLockTime(0) {}
-CMutableTransaction::CMutableTransaction(const CTransaction& tx) : vin(tx.vin), vout(tx.vout), nVersion(tx.nVersion), nLockTime(tx.nLockTime) {}
+CMutableTransaction::CMutableTransaction() : nVersion(CTransaction::CURRENT_VERSION), nLockTime(0), nExpiry(0) {}
+CMutableTransaction::CMutableTransaction(const CTransaction& tx) : vin(tx.vin), vout(tx.vout), nVersion(tx.nVersion), nLockTime(tx.nLockTime), nExpiry(tx.nExpiry) {}
 
 uint256 CMutableTransaction::GetHash() const
 {
@@ -76,9 +76,9 @@ uint256 CTransaction::GetWitnessHash() const
 }
 
 /* For backward compatibility, the hash is initialized to 0. TODO: remove the need for this default constructor entirely. */
-CTransaction::CTransaction() : vin(), vout(), nVersion(CTransaction::CURRENT_VERSION), nLockTime(0), hash() {}
-CTransaction::CTransaction(const CMutableTransaction &tx) : vin(tx.vin), vout(tx.vout), nVersion(tx.nVersion), nLockTime(tx.nLockTime), hash(ComputeHash()) {}
-CTransaction::CTransaction(CMutableTransaction &&tx) : vin(std::move(tx.vin)), vout(std::move(tx.vout)), nVersion(tx.nVersion), nLockTime(tx.nLockTime), hash(ComputeHash()) {}
+CTransaction::CTransaction() : vin(), vout(), nVersion(CTransaction::CURRENT_VERSION), nLockTime(0), nExpiry(0), hash() {}
+CTransaction::CTransaction(const CMutableTransaction &tx) : vin(tx.vin), vout(tx.vout), nVersion(tx.nVersion), nLockTime(tx.nLockTime), nExpiry(tx.nExpiry), hash(ComputeHash()) {}
+CTransaction::CTransaction(CMutableTransaction &&tx) : vin(std::move(tx.vin)), vout(std::move(tx.vout)), nVersion(tx.nVersion), nLockTime(tx.nLockTime), nExpiry(tx.nExpiry), hash(ComputeHash()) {}
 
 CAmount CTransaction::GetValueOut() const
 {
@@ -99,12 +99,13 @@ unsigned int CTransaction::GetTotalSize() const
 std::string CTransaction::ToString() const
 {
     std::string str;
-    str += strprintf("CTransaction(hash=%s, ver=%d, vin.size=%u, vout.size=%u, nLockTime=%u)\n",
+    str += strprintf("CTransaction(hash=%s, ver=%d, vin.size=%u, vout.size=%u, nLockTime=%u, nExpiry=%u)\n",
         GetHash().ToString().substr(0,10),
         nVersion,
         vin.size(),
         vout.size(),
-        nLockTime);
+        nLockTime,
+        nExpiry);
     for (const auto& tx_in : vin)
         str += "    " + tx_in.ToString() + "\n";
     for (const auto& tx_in : vin)

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -282,6 +282,7 @@ public:
     const std::vector<CTxOut> vout;
     const int32_t nVersion;
     const uint32_t nLockTime;
+    const uint32_t nExpiry;
 
 private:
     /** Memory only. */
@@ -365,6 +366,7 @@ struct CMutableTransaction
     std::vector<CTxOut> vout;
     int32_t nVersion;
     uint32_t nLockTime;
+    uint32_t nExpiry;
 
     CMutableTransaction();
     CMutableTransaction(const CTransaction& tx);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -101,6 +101,10 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.push_back(Pair("bits", strprintf("%08x", blockindex->nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
+    result.push_back(Pair("stakedifficulty", std::to_string(blockindex->nStakeDifficulty)));
+    result.push_back(Pair("votebits", strprintf("%08x", blockindex->nVoteBits)));
+    result.push_back(Pair("ticketpoolsize", strprintf("%08x", blockindex->nTicketPoolSize)));
+    result.push_back(Pair("ticketlotterystate", blockindex->pstakeNode->FinalStateToString()));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
@@ -145,6 +149,10 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.push_back(Pair("bits", strprintf("%08x", block.nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
+    result.push_back(Pair("stakedifficulty", std::to_string(blockindex->nStakeDifficulty)));
+    result.push_back(Pair("votebits", strprintf("%08x", blockindex->nVoteBits)));
+    result.push_back(Pair("ticketpoolsize", strprintf("%08x", blockindex->nTicketPoolSize)));
+    result.push_back(Pair("ticketlotterystate", blockindex->pstakeNode->FinalStateToString()));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -675,6 +675,13 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     }
     result.push_back(Pair("curtime", pblock->GetBlockTime()));
     result.push_back(Pair("bits", strprintf("%08x", pblock->nBits)));
+    result.push_back(Pair("stakedifficulty", std::to_string(pblock->nStakeDifficulty)));
+    result.push_back(Pair("votebits", strprintf("%08x", pblock->nVoteBits)));
+    result.push_back(Pair("ticketpoolsize", strprintf("%08x", pblock->nTicketPoolSize)));
+    std::string ticketLotteryStateString;
+    for (auto c : pblock->ticketLotteryState)
+        ticketLotteryStateString += std::to_string((int)c) + " ";
+    result.push_back(Pair("ticketlotterystate", ticketLotteryStateString));
     result.push_back(Pair("height", static_cast<int64_t>((pindexPrev->nHeight+1))));
 
     if (!pblocktemplate->vchCoinbaseCommitment.empty() && fSupportsSegwit) {

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -521,6 +521,7 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
             "    }\n"
             "3. locktime                  (numeric, optional, default=0) Raw locktime. Non-0 value also locktime-activates inputs\n"
             "4. replaceable               (boolean, optional, default=false) Marks this transaction as BIP125 replaceable.\n"
+            "5. expiry                    (numeric, optional, default=0) Expiration height. 0 value means no expiry."
             "                             Allows this transaction to be replaced by a transaction with higher fees. If provided, it is an error if explicit sequence numbers are incompatible.\n"
             "\nResult:\n"
             "\"transaction\"              (string) hex string of the transaction\n"
@@ -643,6 +644,13 @@ UniValue createrawtransaction(const JSONRPCRequest& request)
 
     if (!request.params[3].isNull() && rbfOptIn != SignalsOptInRBF(rawTx)) {
         throw JSONRPCError(RPCErrorCode::INVALID_PARAMETER, "Invalid parameter combination: Sequence number(s) contradict replaceable option");
+    }
+
+    if (!request.params[4].isNull()) {
+        int64_t nExpiry = request.params[4].get_int64();
+        if (nExpiry < 0 || nExpiry > std::numeric_limits<uint32_t>::max())
+            throw JSONRPCError(RPCErrorCode::INVALID_PARAMETER, "Invalid parameter, expiry out of range");
+        rawTx.nExpiry = nExpiry;
     }
 
     return EncodeHexTx(rawTx);

--- a/src/stake/stakenode.cpp
+++ b/src/stake/stakenode.cpp
@@ -128,6 +128,16 @@ StakeState StakeNode::FinalState() const
     return finalState;
 }
 
+std::string StakeNode::FinalStateToString() const
+{
+    std::string str;
+
+    for (auto c : finalState)
+        str += std::to_string((int)c);
+
+    return str;
+}
+
 uint32_t StakeNode::Height() const
 {
     return height;

--- a/src/stake/stakenode.h
+++ b/src/stake/stakenode.h
@@ -120,6 +120,9 @@ public:
     // FinalState returns the final state lottery checksum of the node.
     StakeState FinalState() const;
 
+    // FinalStateToString returns the final state lottery checksum as a printable string.
+    std::string FinalStateToString() const;
+
     // Height returns the height of the node.
     uint32_t Height() const;
 

--- a/src/stake/staketx.cpp
+++ b/src/stake/staketx.cpp
@@ -412,3 +412,26 @@ bool ValidateRevokeTicketStructure(const CTransaction &tx, std::string& reason)
 
     return true;
 }
+
+StakeSlice::StakeSlice(std::vector<CTransactionRef> vtx)
+{
+    for (size_t i=1; i<vtx.size(); i++) // skip coinbase
+    {
+        auto txCl = ParseTxClass(*vtx[i]);
+        if (txCl == TX_Regular)
+            break;  // reached the end of stake transactions
+        push_back(vtx[i]);
+    }
+}
+
+StakeSlice::StakeSlice(std::vector<CTransactionRef> vtx, ETxClass txClass)
+{
+    for (size_t i=1; i<vtx.size(); i++) // skip coinbase
+    {
+        auto txCl = ParseTxClass(*vtx[i]);
+        if (txCl == TX_Regular)
+            break;  // reached the end of stake transactions
+        if (txCl == txClass)
+            push_back(vtx[i]);
+    }
+}

--- a/src/stake/staketx.h
+++ b/src/stake/staketx.h
@@ -105,4 +105,29 @@ bool ValidateBuyTicketStructure(const CTransaction& tx, std::string& reason);
 bool ValidateVoteStructure(const CTransaction& tx, std::string& reason);
 bool ValidateRevokeTicketStructure(const CTransaction& tx, std::string& reason);
 
+// ==============================
+
+// StakeSlice is a helper class that makes it easier to traverse stake transactions of a block.
+// It assumes that transactions in the original container satisfy the rules that:
+// - The first transaction is the coinbase
+// - Then follow stake transactions in any order
+// - Then follow regular transactions
+// Example usage:
+// for (const auto& tx : StakeSlice(block.vtx, TX_BuyTicket))  // traverses BuyTicket transactions
+// or:
+// for (const auto& tx : StakeSlice(block.vtx))                // traverses all stake transactions
+// Implementation details:
+// The current implementation uses a simple but non-optimal approach:
+// It makes a copy of transaction references into a new local container that contain only the desired transactions.
+// Making a temp vector shouldn't be too big a deal since there aren't many stake transactions in blocks.
+// However, a better implementation should rather provide a custom range or custom iterators over the given container.
+// Also, in case we'd need a slice of regular transactions as well, we wouldn't have it using this approach as it would be costly.
+// So feel free to reimplement.
+class StakeSlice : public std::vector<CTransactionRef>
+{
+public:
+    StakeSlice(std::vector<CTransactionRef> vtx);
+    StakeSlice(std::vector<CTransactionRef> vtx, ETxClass txClass);
+};
+
 #endif //PAICOIN_STAKE_STAKETX_H

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -327,6 +327,10 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                 pindexNew->nTime          = diskindex.nTime;
                 pindexNew->nBits          = diskindex.nBits;
                 pindexNew->nNonce         = diskindex.nNonce;
+                pindexNew->nStakeDifficulty = diskindex.nStakeDifficulty;
+                pindexNew->nVoteBits      = diskindex.nVoteBits;
+                pindexNew->nTicketPoolSize = diskindex.nTicketPoolSize;
+                pindexNew->ticketLotteryState = diskindex.ticketLotteryState;
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
 


### PR DESCRIPTION
* Added nStakeDifficulty, nVoteBits, nTicketPoolSize and nTicketLotteryState to block header
* Removed a separate container of stake transactions in the block
* Added an iterator for easy traversal of transactions of a particular type (note: its implementation could be better)
* Added nExpiry to transaction definition
* Added many stake-related validation checks