### PR TITLE
Replaced UniValue constructor for size_t with explicit casting where needed.

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1864,7 +1864,7 @@ UniValue computeBlocksTxFees(uint32_t startBlockHeight, uint32_t endBlockHeight)
     CAmount stdDevValue = computeStdDevAmount(txFees);
 
     UniValue blockResult{UniValue::VOBJ};
-    blockResult.push_back(Pair("number", txFees.size()));
+    blockResult.push_back(Pair("number", static_cast<uint64_t>(txFees.size())));
     blockResult.push_back(Pair("min", minValue));
     blockResult.push_back(Pair("max", maxValue));
     blockResult.push_back(Pair("mean", meanValue));
@@ -1898,7 +1898,7 @@ UniValue computeMempoolTxFees()
     CAmount stdDevValue = computeStdDevAmount(txFees);
 
     UniValue mempoolResult{UniValue::VOBJ};
-    mempoolResult.push_back(Pair("number", numFees));
+    mempoolResult.push_back(Pair("number", static_cast<uint64_t>(numFees)));
     mempoolResult.push_back(Pair("min", minValue));
     mempoolResult.push_back(Pair("max", maxValue));
     mempoolResult.push_back(Pair("mean", meanValue));

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -41,11 +41,6 @@ public:
     UniValue(double val_) {
         setFloat(val_);
     }
-#if defined(__clang__)
-    UniValue(std::size_t val_) {
-        setInt(val_);
-    }
-#endif
     UniValue(const std::string& val_) {
         setStr(val_);
     }
@@ -63,9 +58,6 @@ public:
     bool setInt(uint64_t val);
     bool setInt(int64_t val);
     bool setInt(int val_) { return setInt((int64_t)val_); }
-#if defined(__clang__)
-    bool setInt(std::size_t val);
-#endif
     bool setFloat(double val);
     bool setStr(const std::string& val);
     bool setArray();
@@ -239,15 +231,6 @@ static inline std::pair<std::string,UniValue> Pair(const char *cKey, double dVal
     UniValue uVal(dVal);
     return std::make_pair(key, uVal);
 }
-
-#if defined(__clang__)
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, std::size_t sizeVal)
-{
-    std::string key(cKey);
-    UniValue uVal(sizeVal);
-    return std::make_pair(key, uVal);
-}
-#endif
 
 static inline std::pair<std::string,UniValue> Pair(const char *cKey, const UniValue& uVal)
 {

--- a/src/univalue/lib/univalue.cpp
+++ b/src/univalue/lib/univalue.cpp
@@ -74,17 +74,6 @@ bool UniValue::setInt(int64_t val_)
     return setNumStr(oss.str());
 }
 
-#if defined(__clang__)
-bool UniValue::setInt(std::size_t val_)
-{
-    ostringstream oss;
-
-    oss << val_;
-
-    return setNumStr(oss.str());
-}
-#endif
-
 bool UniValue::setFloat(double val_)
 {
     ostringstream oss;

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3772,7 +3772,7 @@ UniValue getmultisigoutinfo(const JSONRPCRequest& request)
                 int nRequired;
                 if (ExtractDestinations(redeemScript, type, addresses, nRequired)) {
                     result.push_back(Pair("m", nRequired));
-                    result.push_back(Pair("n", addresses.size()));
+                    result.push_back(Pair("n", static_cast<uint64_t>(addresses.size())));
                     auto pubkeys = UniValue{UniValue::VARR};
                     for (const auto& addr: addresses){
                         CPubKey pubkey;
@@ -3797,7 +3797,7 @@ UniValue getmultisigoutinfo(const JSONRPCRequest& request)
                 while (idx < spendingWtx.tx->vin.size() && spendingWtx.tx->vin[idx].prevout.hash != wtx.GetHash()) ++idx;
                 assert( idx < spendingWtx.tx->vin.size());
 
-                result.push_back(Pair("spentbyindex", idx));
+                result.push_back(Pair("spentbyindex", static_cast<uint64_t>(idx)));
             } else {
                 result.push_back(Pair("spent",false));
             }


### PR DESCRIPTION
In order to solve the compilation issues that arise on different OS-compiler combinations, the use of an overloaded constructor for size_t in UniValue has been replaced with the explicit casting where needed.