### PR TITLE
Issue #46: [Integration Testing] Porting of Decred's integration test…

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -174,7 +174,8 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     }
 
     // Get the newly purchased tickets
-    if (nHeight >= chainparams.GetConsensus().nStakeEnabledHeight) {
+    // if (nHeight >= chainparams.GetConsensus().nStakeEnabledHeight) 
+    {
         auto& tx_class_index = mempool.mapTx.get<tx_class>();
         auto existingTickets = tx_class_index.equal_range(ETxClass::TX_BuyTicket);
         int nNewTickets = 0;

--- a/src/test/test_paicoin.cpp
+++ b/src/test/test_paicoin.cpp
@@ -170,6 +170,308 @@ TestChain100Setup::~TestChain100Setup()
 }
 
 
+
+Generator::Generator(const std::string& chainName)
+: TestingSetup(chainName)
+, coinbaseKey{ [](){
+    auto key = CKey();
+    key.MakeNewKey(true/*compressed as in TestChain100Setup*/);
+    return key;}()
+  }
+, stakeKey{coinbaseKey}, rewardKey{coinbaseKey}, changeKey{coinbaseKey}
+, coinbaseAddr{coinbaseKey.GetPubKey().GetID()},stakeAddr{coinbaseAddr}, rewardAddr{coinbaseAddr}, changeAddr{coinbaseAddr}
+, coinbaseScript{GetScriptForDestination(coinbaseAddr)}, stakeScript{coinbaseScript}, rewardScript{coinbaseScript}, changeScript{coinbaseScript}
+{
+    tipName = "genesis"; // genesis block created in TestingSetup
+    // coinbaseKey.MakeNewKey(true);
+    // coinbaseAddr = coinbaseKey.GetPubKey().GetID();
+    // coinbaseScript = CScript() << OP_DUP << OP_HASH160 << ToByteVector(coinbaseAddr) << OP_EQUALVERIFY << OP_CHECKSIG;
+    // use same key, address and script
+    // stakeKey = rewardKey = changeKey = coinbaseKey;
+    // stakeAddr = rewardAddr = changeAddr = p2shOpTrueAddr;
+    // stakeScript = rewardScript = changeScript = coinbaseScript = p2shOpTrueScript;
+}
+
+Generator::~Generator()
+{
+    ;
+}
+
+void Generator::SignTx(CMutableTransaction& tx, unsigned int nIn, const CScript& script, const CKey& key)
+{
+    std::vector<unsigned char> vchSig;
+    uint256 hash = SignatureHash(script, tx, nIn, SIGHASH_ALL, 0, SIGVERSION_BASE);
+    key.Sign(hash, vchSig);
+    vchSig.push_back((unsigned char)SIGHASH_ALL);
+    tx.vin[nIn].scriptSig << vchSig << ToByteVector(key.GetPubKey());
+}
+
+CMutableTransaction Generator::CreateTicketPurchaseTx(const SpendableOut& spend, const CAmount& ticketPrice, const CAmount& fee)
+{
+    CMutableTransaction mtx;
+    // create input to fund the transaction
+    const auto& txin = CTxIn(spend.prevOut.hash, spend.prevOut.n);
+    mtx.vin.push_back(txin);
+
+    // create a structured OP_RETURN output containing tx declaration
+    BuyTicketData buyTicketData = { 1 };    // version
+    CScript declScript = GetScriptForBuyTicketDecl(buyTicketData);
+    mtx.vout.push_back(CTxOut(0, declScript));
+
+    // create an output that pays ticket stake
+    mtx.vout.push_back(CTxOut(ticketPrice, stakeScript));
+
+    // create an OP_RETURN push containing a dummy address to send rewards to, and the amount contributed to stake
+    TicketContribData ticketContribData = { 1, rewardAddr, ticketPrice + fee };
+    CScript contributorInfoScript = GetScriptForTicketContrib(ticketContribData);
+    mtx.vout.push_back(CTxOut(0, contributorInfoScript));
+
+    // create an output which pays back change
+    CAmount change = spend.amount - ticketPrice - fee;
+    mtx.vout.push_back(CTxOut(change, changeScript));
+
+    SignTx(mtx, 0, coinbaseScript, coinbaseKey);
+    
+    boughtTicketHashToPrice[mtx.GetHash()] = ticketPrice;
+
+    return mtx;
+}
+    
+CMutableTransaction Generator::CreateVoteTx(const CBlockIndex& voteBlock, const uint256& ticketTxHash)
+{
+    CMutableTransaction mtx;
+
+    const auto& voterSubsidy = GetVoterSubsidy(voteBlock.nHeight+1/*spend height*/,Params().GetConsensus());
+    const auto& ticketPrice  = boughtTicketHashToPrice[ticketTxHash];
+    const auto& contributedAmount = ticketPrice + 2 /*fee*/;
+    const auto& reward = CalcContributorRemuneration( contributedAmount, ticketPrice, voterSubsidy, contributedAmount);
+    // create a reward generation input
+    mtx.vin.push_back(CTxIn(COutPoint(), CScript() << 55 << OP_0/*added to avoid bad-stakereward-length; TODO set correct script*/));
+
+    mtx.vin.push_back(CTxIn(COutPoint(ticketTxHash, ticketStakeOutputIndex)));
+
+    // create a structured OP_RETURN output containing tx declaration and voting data
+    uint32_t voteYesBits = 0x0001;
+    int voteVersion = 1;
+    VoteData voteData = { voteVersion, voteBlock.GetBlockHash(), static_cast<uint32_t>(voteBlock.nHeight), voteYesBits };
+    CScript declScript = GetScriptForVoteDecl(voteData);
+    mtx.vout.push_back(CTxOut(0, declScript));
+
+    // Create an output which pays back a dummy reward
+    CScript rewardScript = GetScriptForDestination(rewardAddr);
+    mtx.vout.push_back(CTxOut(reward, rewardScript));
+
+    SignTx(mtx, voteStakeInputIndex, stakeScript, coinbaseKey);
+
+    return mtx;
+}
+
+CMutableTransaction Generator::CreateRevocationTx(const uint256& ticketTxHash)
+{
+    CMutableTransaction mtx;
+
+    // create an input from the purchased ticket stake
+    mtx.vin.push_back(CTxIn(COutPoint(ticketTxHash, ticketStakeOutputIndex)));
+
+    // create a structured OP_RETURN output containing tx declaration
+    RevokeTicketData revokeTicketData = { 1 };
+    CScript declScript = GetScriptForRevokeTicketDecl(revokeTicketData);
+    mtx.vout.push_back(CTxOut(0, declScript));
+
+    // Create an output which pays back ticket price as a refund
+    CScript rewardScript = GetScriptForDestination(rewardAddr);
+    const auto& ticketPrice  = boughtTicketHashToPrice[ticketTxHash]; 
+    mtx.vout.push_back(CTxOut(ticketPrice, rewardScript));
+
+    SignTx(mtx, revocationStakeInputIndex, stakeScript, coinbaseKey);
+
+    return mtx;
+}
+
+CMutableTransaction Generator::CreateSpendTx(const SpendableOut& spend, const CAmount& fee)
+{
+    CMutableTransaction mtx;
+    // create input to fund the transaction
+    const auto& txin = CTxIn(spend.prevOut.hash, spend.prevOut.n);
+    mtx.vin.push_back(txin);
+
+    // create an output that spends all 
+    mtx.vout.push_back(CTxOut(spend.amount - fee, rewardScript));
+
+    SignTx(mtx, spend.prevOut.n, coinbaseScript, coinbaseKey);
+    
+    return mtx;
+}
+
+CMutableTransaction Generator::CreateSplitSpendTx(const SpendableOut& spend, const std::vector<CAmount>& payments, const CAmount& fee)
+{
+    CMutableTransaction mtx;
+    // create input to fund the transaction
+    const auto& txin = CTxIn(spend.prevOut.hash, spend.prevOut.n);
+    mtx.vin.push_back(txin);
+
+    // create an output that spends all
+    auto sum = CAmount(0);
+    for (const auto& payment: payments){
+        mtx.vout.push_back(CTxOut(payment, rewardScript));
+        sum += payment;
+    }
+
+    mtx.vout.push_back(CTxOut(spend.amount - sum - fee, changeScript));
+
+    SignTx(mtx, spend.prevOut.n, coinbaseScript, coinbaseKey);
+    
+    return mtx;
+}
+
+void Generator::SaveCoinbaseOut(const CBlock& b)
+{
+    SaveSpendableOuts(b, 0UL /*coinbase tx*/, {0UL});
+}
+
+void Generator::SaveSpendableOuts(const CBlock& b, uint32_t indexBlock, const std::vector<uint32_t>& indicesTxOut)
+{
+    const auto& tx = b.vtx[indexBlock];
+    auto outs = std::list<SpendableOut>{};
+    for (const auto& indexTxOut : indicesTxOut) {
+        outs.push_back(MakeSpendableOut(*tx, indexTxOut));
+    }
+    spendableOuts.push_back(outs);
+}
+
+void Generator::SaveAllSpendableOuts(const CBlock& b)
+{
+    auto outs = std::list<SpendableOut>{};
+    for (const auto& tx : b.vtx ) {
+        if (tx->IsCoinBase()) {
+            outs.push_back(MakeSpendableOut(*tx, 0UL));
+        }
+        else {
+            // we assume that these outputs are not spent inside the same block
+            const auto& txClass = ParseTxClass(*tx);
+            switch(txClass){
+            case TX_Regular:
+                for (int i = 0; i < tx->vout.size(); ++i) { 
+                    outs.push_back(MakeSpendableOut(*tx, i));
+                }
+                break;
+            case TX_BuyTicket:
+                outs.push_back(MakeSpendableOut(*tx, ticketChangeOutputIndex));
+                break;
+            case TX_RevokeTicket:
+                outs.push_back(MakeSpendableOut(*tx, revocationRefundOutputIndex));
+                break;
+            }
+        }
+    }
+    spendableOuts.push_back(outs);
+}
+
+Generator::SpendableOut Generator::MakeSpendableOut(const CTransaction& tx, uint32_t indexOut)
+{
+    return Generator::SpendableOut{COutPoint{tx.GetHash(), indexOut}, Tip()->nHeight, tx.vout[indexOut].nValue};
+}
+
+std::list<Generator::SpendableOut> Generator::OldestCoinOuts()
+{
+    const auto oldest = spendableOuts.front();
+    spendableOuts.pop_front();
+    return oldest;
+}
+
+const CBlockIndex* Generator::Tip()
+{
+    const auto& tip = chainActive.Tip();
+    return tip;
+}
+
+const Consensus::Params& Generator::ConsensusParams()
+{
+    return Params().GetConsensus();
+}
+
+CAmount Generator::NextRequiredStakeDifficulty()
+{
+    CBlock dummyBlock;
+    const auto& ticketPrice = calcNextRequiredStakeDifficulty(dummyBlock, chainActive.Tip(), Params());
+    return ticketPrice;
+}
+
+CBlock Generator::NextBlock(const std::string& blockName
+                    , const SpendableOut* spend
+                    , const std::list<SpendableOut>& ticketSpends
+                    , const MungerType& munger)
+{
+    const CChainParams& chainparams = Params();
+    const Consensus::Params& params = chainparams.GetConsensus();
+
+    TestMemPoolEntryHelper entry;
+    const auto& nextHeight = chainActive.Tip()->nHeight + 1;
+
+    mempool.clear();
+
+    if (nextHeight > COINBASE_MATURITY) {
+        // Generate votes once the stake validation height has been
+        // reached.
+        if (nextHeight >= params.nStakeValidationHeight){
+            // Generate and add the vote transactions for the winning tickets
+            const auto& winners = chainActive.Tip()->pstakeNode->Winners();
+            for (const auto& ticket: winners) {
+                const auto& voteTx = CreateVoteTx(*chainActive.Tip(), ticket);
+                mempool.addUnchecked(voteTx.GetHash(), entry.Fee(0LL).SpendsCoinbase(false).FromTx(voteTx));
+            }
+        }
+
+        // if (nextHeight >= params.nStakeEnabledHeight)
+        {
+            const auto& ticketPrice = NextRequiredStakeDifficulty();
+            const auto& ticketFee = CAmount(2);
+            for (const auto& it : ticketSpends){
+                const auto& purchaseTx = CreateTicketPurchaseTx(it, ticketPrice, ticketFee);
+                mempool.addUnchecked(purchaseTx.GetHash(), entry.Fee(0LL).SpendsCoinbase(true).FromTx(purchaseTx));
+            }
+        }
+
+        // Generate and add revocations for any missed tickets.
+        const auto& misses = chainActive.Tip()->pstakeNode->MissedTickets();
+        for (const auto& missedHash: misses) {
+            const auto& revocationTx = CreateRevocationTx(missedHash);
+            mempool.addUnchecked(revocationTx.GetHash(), entry.Fee(0LL).SpendsCoinbase(false).FromTx(revocationTx));
+        }
+    } 
+
+    if (spend != nullptr)
+    {
+        const auto& fee = CAmount(2000);
+        const auto& spendTx = CreateSpendTx(*spend, fee);
+        mempool.addUnchecked(spendTx.GetHash(), entry.Fee(fee).SpendsCoinbase(false).FromTx(spendTx));
+    }
+
+    std::unique_ptr<CBlockTemplate> pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(coinbaseScript);
+    CBlock& block = pblocktemplate->block;
+
+    if (munger){
+        // Replace mempool-selected txns with just coinbase plus the txns done in munger:
+        mempool.clear();
+        const auto& mungerTxs = munger(block);
+        block.vtx.resize(1);
+        for (const CMutableTransaction& tx : mungerTxs)
+            block.vtx.push_back(MakeTransactionRef(tx));
+    }
+
+    // IncrementExtraNonce creates a valid coinbase and merkleRoot
+    unsigned int extraNonce = 0;
+    IncrementExtraNonce(&block, chainActive.Tip(), extraNonce);
+
+    while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
+
+    std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
+    ProcessNewBlock(chainparams, shared_pblock, true, nullptr);
+
+    CBlock result = block;
+    return result;
+}
+
 CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(const CMutableTransaction &tx) {
     CTransaction txn(tx);
     return FromTx(txn);

--- a/src/test/test_paicoin.h
+++ b/src/test/test_paicoin.h
@@ -13,6 +13,7 @@
 #include "scheduler.h"
 #include "txdb.h"
 #include "txmempool.h"
+#include "script/standard.h"
 
 #include <boost/thread.hpp>
 
@@ -87,6 +88,87 @@ struct TestChain100Setup : public TestingSetup {
 
     std::vector<CTransaction> coinbaseTxns; // For convenience, coinbase transactions
     CKey coinbaseKey; // private/public key needed to spend coinbase transactions
+};
+
+class Generator: public TestingSetup
+{
+public:
+    explicit Generator(const std::string& chainName = CBaseChainParams::REGTEST);
+    ~Generator();
+
+    struct SpendableOut {
+        COutPoint prevOut;
+        int       blockHeight;
+        // uint32_t  blockIndex;
+        CAmount   amount;
+    };
+
+    // struct StakeTicket {
+    //     CTransactionRef tx;
+    //     uint32_t  blockHeight;
+    //     uint32_t  blockIndex;
+    // };
+    typedef std::function<std::vector<CMutableTransaction>(const CBlock&)> MungerType;
+
+    CBlock NextBlock(const std::string& blockName
+                    , const SpendableOut* spend
+                    , const std::list<SpendableOut>& ticketSpends
+                    , const MungerType& munger = MungerType());
+    CMutableTransaction CreateTicketPurchaseTx(const SpendableOut& spend, const CAmount& ticketPrice, const CAmount& fee);
+    CMutableTransaction CreateVoteTx(const CBlockIndex& voteBlock, const uint256& ticketTxHash);
+    CMutableTransaction CreateRevocationTx(const uint256& ticketTxHash);
+    CMutableTransaction CreateSpendTx(const SpendableOut& spend, const CAmount& fee);
+    CMutableTransaction CreateSplitSpendTx(const SpendableOut& spend, const std::vector<CAmount>& payments, const CAmount& fee);
+    
+    const CBlockIndex* Tip();
+    const Consensus::Params& ConsensusParams();
+    CAmount NextRequiredStakeDifficulty();
+
+    SpendableOut MakeSpendableOut(const CTransaction& tx, uint32_t indexOut);
+    void SaveAllSpendableOuts(const CBlock& b);
+    void SaveSpendableOuts(const CBlock& b, uint32_t indexBlock, const std::vector<uint32_t>& indicesTxOut);
+    void SaveCoinbaseOut(const CBlock& b);
+    std::list<SpendableOut> OldestCoinOuts();
+
+private:
+    void SignTx(CMutableTransaction& tx, unsigned int nIn, const CScript& script, const CKey& key);
+
+    // keep keys, addr and scripts as references to the coinbase ones to be
+    // in case we need to make separate ones
+    const CKey  coinbaseKey;
+    const CKey& stakeKey;
+    const CKey& rewardKey;
+    const CKey& changeKey;
+
+    const CKeyID  coinbaseAddr;
+    const CKeyID& stakeAddr;
+    const CKeyID& rewardAddr;
+    const CKeyID& changeAddr;
+
+    const CScript  coinbaseScript;
+    const CScript& stakeScript;
+    const CScript& rewardScript;
+    const CScript& changeScript;
+
+    std::string tipName;
+    // std::map<uint256,CBlock&> blocks;//           map[chainhash.Hash]*wire.MsgBlock
+    // std::map<uint256,uint32_t> blockHeights;//     map[chainhash.Hash]uint32
+    // std::map<std::string,CBlock&> blocksByName;//     map[string]*wire.MsgBlock
+
+    // Used for tracking spendable coinbase outputs.
+    std::list<std::list<SpendableOut>> spendableOuts;//     [][]SpendableOut
+    // prevCollectedHash chainhash.Hash
+
+    // // Used for tracking the live ticket pool and revocations.
+    // originalParents map[chainhash.Hash]chainhash.Hash
+    // std::vector<CTransactionRef> immatureTickets;
+    // std::vector<CTransactionRef> liveTickets;
+    // std::vector<CTransactionRef> expiredTickets;
+    // std::map<uint256, std::vector<StakeTicket>> wonTickets;//      map[chainhash.Hash][]*stakeTicket
+    // std::map<uint256, std::vector<StakeTicket>> revokedTickets;//  map[chainhash.Hash][]*stakeTicket
+    // missedVotes     map[chainhash.Hash]*stakeTicket
+
+    std::map<uint256, CAmount> boughtTicketHashToPrice;
 };
 
 class CTxMemPoolEntry;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3118,7 +3118,7 @@ CAmount calcNextRequiredStakeDifficulty(const CBlock& block, const CBlockIndex *
     if (blockHeight >= params.GetConsensus().nStakeValidationHeight)
         return 1 * COIN;
     else
-        return 0;
+        return params.GetConsensus().nMinimumStakeDiff;
 }
 
 static bool CheckBlockHeader(const CBlockHeader& block, CValidationState& state, const Consensus::Params& consensusParams, int nBlockHeight, bool fCheckPOW = true)


### PR DESCRIPTION
…s to our implementation

* added a first port of DisconnectNode function
* added index to multi_index container in mempool to sort after tx_class prio
* added index to sort by voted block hash and by simple TxClass
* added composite key and special comparer for buy transactions
* created a chain w/o coinbase keys to use the same unit tests on regtest
* added code to put votes first in the block and started unit test for having stake txs
* refactored TestChain100Setup to have more script pk types
* added tickets to the new block using mempool
* handled revocations
* added votes in the block that contains the revocations
* changed miner_test and params to hit code handling expired tickets
* sorted new tickets also by descendants in mempool

* added an implementation of Decred's Generator, to be used a framework for unit testing
* used the chainActive and mempool construct the chain ( our Generator is not a parallel implemenation as in Decred)
* added functions to create purchases, votes and revocation in the Generator
* added munger and example usage code
* used mungers to purchase max number of tickets
* added revocation checks after expiration height