### PR TITLE
develop: qt: Replace objc_msgSend() function calls with the native Objective-C syntax.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -435,7 +435,7 @@ case $host in
      fi
 
      AX_CHECK_LINK_FLAG([[-Wl,-headerpad_max_install_names]], [LDFLAGS="$LDFLAGS -Wl,-headerpad_max_install_names"])
-     CPPFLAGS="$CPPFLAGS -DMAC_OSX"
+     CPPFLAGS="$CPPFLAGS -DMAC_OSX -DOBJC_OLD_DISPATCH_PROTOTYPES=0"
      OBJCXXFLAGS="$CXXFLAGS"
      ;;
    *linux*)

--- a/src/qt/macdockiconhandler.mm
+++ b/src/qt/macdockiconhandler.mm
@@ -11,8 +11,8 @@
 
 #undef slots
 #include <Cocoa/Cocoa.h>
-#include <objc/objc.h>
-#include <objc/message.h>
+#include <AppKit/AppKit.h>
+#include <objc/runtime.h>
 
 #if QT_VERSION < 0x050000
 extern void qt_mac_set_dock_menu(QMenu *);
@@ -31,18 +31,12 @@ bool dockClickHandler(id self,SEL _cmd,...) {
 }
 
 void setupDockClickHandler() {
-    Class cls = objc_getClass("NSApplication");
-    id appInst = objc_msgSend((id)cls, sel_registerName("sharedApplication"));
-    
-    if (appInst != nullptr) {
-        id delegate = objc_msgSend(appInst, sel_registerName("delegate"));
-        Class delClass = (Class)objc_msgSend(delegate,  sel_registerName("class"));
-        SEL shouldHandle = sel_registerName("applicationShouldHandleReopen:hasVisibleWindows:");
-        if (class_getInstanceMethod(delClass, shouldHandle))
-            class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:");
-        else
-            class_addMethod(delClass, shouldHandle, (IMP)dockClickHandler,"B@:");
-    }
+    Class delClass = (Class)[[[NSApplication sharedApplication] delegate] class];
+    SEL shouldHandle = sel_registerName("applicationShouldHandleReopen:hasVisibleWindows:");
+    if (class_getInstanceMethod(delClass, shouldHandle))
+        class_replaceMethod(delClass, shouldHandle, (IMP)dockClickHandler, "B@:");
+    else
+        class_addMethod(delClass, shouldHandle, (IMP)dockClickHandler,"B@:");
 }
 
 


### PR DESCRIPTION
After Bitcoin Merge #16720:

Changes in Xcode 11 Objective-C Runtime cause an error (#16387) during building on MacOS 10.15 Catalina.
This PR fixes this issue by replacing `objc_msgSend()` function calls with the native Objective-C syntax.

Refs:
  - [changes in `objc_msgSend` function](https://developer.apple.com/documentation/objectivec/1456712-objc_msgsend?changes=latest_minor&language=objc)
  - [`OBJC_OLD_DISPATCH_PROTOTYPES` macro](https://developer.apple.com/documentation/objectivec/objc_old_dispatch_prototypes?language=objc)