### PR TITLE
Issue #47: Investigate/implement what is missing for having correct b…

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -269,7 +269,7 @@ public:
         consensus.nMaxFreshStakePerBlock       = 4 * consensus.nTicketsPerBlock;
         consensus.nStakeEnabledHeight          = consensus.nCoinbaseMaturity + consensus.nTicketMaturity;
         consensus.nStakeValidationHeight       = 4096;        // ~ 14 days
-        consensus.stakeBaseSigScript           = CScript();//[]byte{0x00, 0x00};
+        consensus.stakeBaseSigScript           = CScript() << 0x00 << 0x00;
         consensus.nStakeMajorityMultiplier     = 3;
         consensus.nStakeMajorityDivisor        = 4;
         //organization related parameters
@@ -427,7 +427,7 @@ public:
         consensus.nMaxFreshStakePerBlock       = 4 * consensus.nTicketsPerBlock;
         consensus.nStakeEnabledHeight          = consensus.nCoinbaseMaturity + consensus.nTicketMaturity;
         consensus.nStakeValidationHeight       = 100000;      // Arbitrary chosen into the future; height is 46261 at the moment
-        consensus.stakeBaseSigScript           = CScript();//[]byte{0x00, 0x00};
+        consensus.stakeBaseSigScript           = CScript() << 0x00 << 0x00;
         consensus.nStakeMajorityMultiplier     = 3;
         consensus.nStakeMajorityDivisor        = 4;
         //organization related parameters
@@ -569,7 +569,7 @@ public:
         consensus.nMaxFreshStakePerBlock       = 4 * consensus.nTicketsPerBlock;
         consensus.nStakeEnabledHeight          = 141;//consensus.nCoinbaseMaturity + consensus.nTicketMaturity;
         consensus.nStakeValidationHeight       = 200;//consensus.nCoinbaseMaturity + (consensus.nTicketPoolSize * 2);
-        consensus.stakeBaseSigScript           = CScript();//[]byte{0x30, 0x57};
+        consensus.stakeBaseSigScript           = CScript() << 0x73 << 0x57;
         consensus.nStakeMajorityMultiplier     = 3;
         consensus.nStakeMajorityDivisor        = 4;
         //organization related parameters

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -215,11 +215,12 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
     else if (txClass == TX_Vote)
     {
         // Check length of subsidy scriptSig.
-        if (tx.vin[voteSubsidyInputIndex].scriptSig.size() < 2 || tx.vin[0].scriptSig.size() > 100)
+        if (tx.vin[voteSubsidyInputIndex].scriptSig.size() < 2 || tx.vin[voteSubsidyInputIndex].scriptSig.size() > 100)
             return state.DoS(100, false, REJECT_INVALID, "bad-stakereward-length");
 
-        // TODO validation
         // Reward scriptSig must be set to the one specified by the network.
+        if (tx.vin[voteSubsidyInputIndex].scriptSig != Params().GetConsensus().stakeBaseSigScript)
+            return state.DoS(100, false, REJECT_INVALID, "bad-stakereward-scriptsig");
 
         // The ticket reference must not be null.
         if (tx.vin[voteStakeInputIndex].prevout.IsNull())

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -904,7 +904,7 @@ CMutableTransaction CreateDummyVote(const uint256& txBuyTicketHash, const uint25
     CMutableTransaction mtx;
 
     // create a reward generation input
-    mtx.vin.push_back(CTxIn(COutPoint(), CScript() << 55 << OP_0 ));
+    mtx.vin.push_back(CTxIn(COutPoint(), Params().GetConsensus().stakeBaseSigScript));
 
     mtx.vin.push_back(CTxIn(COutPoint(txBuyTicketHash, ticketStakeOutputIndex)));
 
@@ -1238,7 +1238,6 @@ BOOST_FIXTURE_TEST_CASE( FakeChainGenerator_stake_REGTEST, Generator)
     // we will use mempool to add stake transaction into the block
     LOCK(cs_main);
     LOCK(::mempool.cs);
-    fCheckpointsEnabled = false;
 
     // buy one ticket
     {
@@ -1264,19 +1263,20 @@ BOOST_FIXTURE_TEST_CASE( FakeChainGenerator_stake_REGTEST, Generator)
 
     // use munger to buy max number of Tickets using a split transaction first to make multiple outs
     {
-        const auto& b = NextBlock("bsp", nullptr, {}, [this](const CBlock& b){
-            std::vector<CMutableTransaction> txns;
+        const auto& b = NextBlock("bsp", nullptr, {}, [this](CBlock& b){
+            BOOST_CHECK_EQUAL(b.vtx.size(), 1);
+            BOOST_CHECK(b.vtx[0]->IsCoinBase());
             const auto& spend = OldestCoinOuts();
             const auto& ticketPrice = NextRequiredStakeDifficulty();
             const auto& ticketFee = CAmount(2000);
             const auto& splitAmounts = std::vector<CAmount>(ConsensusParams().nTicketsPerBlock - 1, ticketPrice + ticketFee);
             const auto& splitSpendTx = CreateSplitSpendTx(spend.front(),splitAmounts,ticketFee);
-            txns.push_back(splitSpendTx);
+            b.vtx.push_back(MakeTransactionRef(splitSpendTx));
+
             for (int i = 0; i <  splitSpendTx.vout.size(); ++i) {
                 const auto& purchaseTx =  CreateTicketPurchaseTx(MakeSpendableOut(splitSpendTx,i), ticketPrice, ticketFee);
-                txns.push_back(purchaseTx);
+                b.vtx.push_back(MakeTransactionRef(purchaseTx));
             }
-            return txns;
         });
         SaveCoinbaseOut(b); //calling SaveAllSpendableOuts here would also save the already spent outs of the split tx
         BOOST_CHECK(Tip()->GetBlockHash() == b.GetHash());
@@ -1284,19 +1284,19 @@ BOOST_FIXTURE_TEST_CASE( FakeChainGenerator_stake_REGTEST, Generator)
         BOOST_CHECK_EQUAL(b.vtx.size(), 1 + 1 + ConsensusParams().nTicketsPerBlock);
     } 
 
-    auto PurchaseMaxTickets = [this](const CBlock& b)
+    auto PurchaseMaxTickets = [this](CBlock& b)
     {
-        std::vector<CMutableTransaction> txns;
+        BOOST_CHECK_EQUAL(b.vtx.size(), 1);
+        BOOST_CHECK(b.vtx[0]->IsCoinBase());
         const auto& spend = OldestCoinOuts();
         const auto& ticketPrice = NextRequiredStakeDifficulty();
         const auto& ticketFee = CAmount(2);
         auto purchaseTx =  CreateTicketPurchaseTx(spend.front(), ticketPrice, ticketFee);
-        txns.push_back(purchaseTx);
-        while(txns.size() < ConsensusParams().nMaxFreshStakePerBlock) {
+        b.vtx.push_back(MakeTransactionRef(purchaseTx));
+        while(b.vtx.size() < ConsensusParams().nMaxFreshStakePerBlock + 1) {
             purchaseTx =  CreateTicketPurchaseTx(MakeSpendableOut(purchaseTx,ticketChangeOutputIndex), ticketPrice, ticketFee);
-            txns.push_back(purchaseTx);
+            b.vtx.push_back(MakeTransactionRef(purchaseTx));
         }
-        return txns;
     };
 
     // ---------------------------------------------------------------------
@@ -1341,29 +1341,21 @@ BOOST_FIXTURE_TEST_CASE( FakeChainGenerator_stake_REGTEST, Generator)
         BOOST_CHECK_EQUAL(b.vtx.size(), 1 + Tip()->pstakeNode->Winners().size() + ticketOuts.size() );
     }
 
-    auto DropSomeVotes = [this](const CBlock& b)
+    auto DropSomeVotes = [this](CBlock& b)
     {
-        std::vector<CMutableTransaction> txns;
         const auto& numberOfWinners = Tip()->pstakeNode->Winners().size();
+        BOOST_CHECK_EQUAL(numberOfWinners, ConsensusParams().nTicketsPerBlock);
+
         const auto& majority = (ConsensusParams().nTicketsPerBlock / 2) + 1;
 
-        BOOST_CHECK_GE(b.vtx.size(), 1 + numberOfWinners);
-        for (int i = 1; i <= majority; ++i) // skip the coinbase, it is always kept and copy enough votes to have the majority
-        {
-            const auto& tx = *b.vtx[i];
-            const auto& txClass = ParseTxClass(tx);
-            BOOST_CHECK_EQUAL(txClass, TX_Vote);
-            txns.push_back(*b.vtx[i]);
-        }
-        for (int i = 1 + numberOfWinners; i < b.vtx.size(); ++i) //copy the rest of txns
-        {
-            const auto& tx = *b.vtx[i];
-            const auto& txClass = ParseTxClass(tx);
-            BOOST_CHECK_NE(txClass, TX_Vote);
-            txns.push_back(*b.vtx[i]);
-        }
+        const auto& initialSize = b.vtx.size();
+        BOOST_CHECK_GE(initialSize, 1 + numberOfWinners);
+        BOOST_CHECK(b.vtx[0]->IsCoinBase());
 
-        return txns;
+        BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[majority]), TX_Vote);
+        BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[numberOfWinners]), TX_Vote);
+        b.vtx.erase(b.vtx.begin() + majority + 1, b.vtx.begin() + numberOfWinners + 1); //leave only the coinbase and a majority of votes
+        BOOST_CHECK_GE(b.vtx.size(), initialSize - (numberOfWinners - majority) );
     };
 
     // build a block where only the majority of votes are kept
@@ -1376,25 +1368,24 @@ BOOST_FIXTURE_TEST_CASE( FakeChainGenerator_stake_REGTEST, Generator)
         BOOST_CHECK_EQUAL(b.vtx.size(), 1 + ((ConsensusParams().nTicketsPerBlock / 2) + 1) + ticketSpends.size() );
     }
 
-    auto PurchaseMaxTicketsMinVotes = [this](const CBlock& b)
+    auto PurchaseMaxTicketsMinVotes = [this](CBlock& b)
     {
-        std::vector<CMutableTransaction> txns;
         const auto& winners = Tip()->pstakeNode->Winners();
         const auto& majority = (ConsensusParams().nTicketsPerBlock / 2) + 1;
-        for(int i = 0; txns.size() < majority && i < winners.size(); ++i) {
-            const auto& voteTx = CreateVoteTx(*Tip(), winners[i]);
-            txns.push_back(voteTx);
-        }
+
+        const auto& voteBlockHash = Tip()->GetBlockHash();
+        const auto& voteBlockHeight = Tip()->nHeight;
+        b.vtx.erase(b.vtx.begin() + majority + 1, b.vtx.end());
+
         const auto& spend = OldestCoinOuts();
         const auto& ticketPrice = NextRequiredStakeDifficulty();
         const auto& ticketFee = CAmount(2);
         auto purchaseTx =  CreateTicketPurchaseTx(spend.front(), ticketPrice, ticketFee);
-        txns.push_back(purchaseTx);
-        while(txns.size() < ConsensusParams().nMaxFreshStakePerBlock + majority) {
+        b.vtx.push_back(MakeTransactionRef(purchaseTx));
+        while(b.vtx.size() < ConsensusParams().nMaxFreshStakePerBlock + majority + 1) {
             purchaseTx =  CreateTicketPurchaseTx(MakeSpendableOut(purchaseTx,ticketChangeOutputIndex), ticketPrice, ticketFee);
-            txns.push_back(purchaseTx);
+            b.vtx.push_back(MakeTransactionRef(purchaseTx));
         }
-        return txns;
     };
 
     // re-construct only a majority of votes and purchase max tickets
@@ -1422,8 +1413,643 @@ BOOST_FIXTURE_TEST_CASE( FakeChainGenerator_stake_REGTEST, Generator)
         // coinbase tx + all winning votes + all missed (revocations) + ticket purchases tx
         BOOST_CHECK_EQUAL(b.vtx.size(), 1 + nWinners + nRevocations + ticketSpends.size() );
     }
-
-    fCheckpointsEnabled = true;
-
 }
+
+BOOST_FIXTURE_TEST_CASE( StakeVoteTests_REGTEST, Generator)
+{
+    BOOST_CHECK_EQUAL(Tip()->nHeight, 0);
+    for (int i = 0; i < COINBASE_MATURITY; ++i) {
+        const auto& b = NextBlock("bcm",nullptr,{});
+        SaveCoinbaseOut(b);
+        BOOST_CHECK(Tip()->GetBlockHash() == b.GetHash());
+    }
+
+    BOOST_CHECK_EQUAL(Tip()->nHeight, COINBASE_MATURITY);
+
+    // we will use mempool to add stake transaction into the block
+    LOCK(cs_main);
+    LOCK(::mempool.cs);
+
+    // stop just before StakeValidationHeight, blocks do not add votes
+    while (Tip()->nHeight < ConsensusParams().nStakeValidationHeight - 1)
+    {
+        // buy one ticket
+        const auto& ticketOuts = OldestCoinOuts();
+        BOOST_CHECK_EQUAL(ticketOuts.size(),1);
+        const auto& b = NextBlock("bsp", nullptr, ticketOuts);
+        SaveAllSpendableOuts(b);
+        BOOST_CHECK(Tip()->GetBlockHash() == b.GetHash());
+        //coinbase tx + the ticket purchase tx
+        BOOST_CHECK_EQUAL(b.vtx.size(),2);
+    }
+
+    auto ticketSpends = OldestCoinOuts(); //we can use this for more test since blocks should be rejected
+
+    // Attempt to add block where vote has a null ticket reference hash.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                CMutableTransaction firstVoteTx = *b.vtx[1]; //0 is coinbase
+                const auto& txClass = ParseTxClass(firstVoteTx);
+                BOOST_CHECK_EQUAL(txClass, TX_Vote);
+                firstVoteTx.vin[voteStakeInputIndex].prevout.hash = {};
+                b.vtx[1] = MakeTransactionRef(firstVoteTx);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "bad-ticket-reference-in-vote");
+    }
+
+    // Attempt to add block with too many votes.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                const auto& numberOfWinners = Tip()->pstakeNode->Winners().size();
+                const auto& initialSize = b.vtx.size();
+                BOOST_CHECK_GE(initialSize, 1 + numberOfWinners);
+
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[numberOfWinners]), TX_Vote);
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[numberOfWinners+1]), TX_BuyTicket);
+
+                CMutableTransaction copyFirstVoteTx = *b.vtx[1];
+                copyFirstVoteTx.vin[voteStakeInputIndex].prevout.hash = Tip()->pstakeNode->LiveTickets()[0];
+                b.vtx.emplace(b.vtx.begin() + numberOfWinners, MakeTransactionRef(copyFirstVoteTx) );
+
+                BOOST_CHECK_GE(b.vtx.size(), initialSize + 1);
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[numberOfWinners]), TX_Vote);
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[numberOfWinners+1]), TX_Vote);
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[numberOfWinners+2]), TX_BuyTicket);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "too-many-votes");
+    }
+
+    // Attempt to add block with too few votes.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                const auto& numberOfWinners = Tip()->pstakeNode->Winners().size();
+                BOOST_CHECK_EQUAL(numberOfWinners, ConsensusParams().nTicketsPerBlock);
+
+                const auto& majority = (ConsensusParams().nTicketsPerBlock / 2) + 1;
+
+                const auto& initialSize = b.vtx.size();
+                BOOST_CHECK_GE(initialSize, 1 + numberOfWinners);
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[majority]), TX_Vote);
+
+                //leave only the coinbase and less than majority of votes
+                b.vtx.erase(b.vtx.begin() + 1, b.vtx.begin() + majority + 1);
+                BOOST_CHECK_GE(b.vtx.size(), initialSize - majority);
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[majority]), TX_BuyTicket);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "too-few-votes");
+    }
+
+    // Attempt to add block with a ticket voting on the parent of the actual
+    // block it should be voting for.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                CMutableTransaction firstVoteTx = *b.vtx[1]; //0 is coinbase
+                const auto& txClass = ParseTxClass(firstVoteTx);
+                BOOST_CHECK_EQUAL(txClass, TX_Vote);
+                const auto& ticketHash = firstVoteTx.vin[voteStakeInputIndex].prevout.hash;
+                /*use prev block hash and height*/
+                firstVoteTx = CreateVoteTx( Tip()->pprev->GetBlockHash()
+                                          , Tip()->pprev->nHeight
+                                          , ticketHash);
+                b.vtx[1] = MakeTransactionRef(firstVoteTx);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "vote-for-wrong-block");
+    }
+
+    // Attempt to add block with a ticket voting on the correct block hash,
+    // but the wrong block height.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                CMutableTransaction firstVoteTx = *b.vtx[1]; //0 is coinbase
+                const auto& txClass = ParseTxClass(firstVoteTx);
+                BOOST_CHECK_EQUAL(txClass, TX_Vote);
+                const auto& ticketHash = firstVoteTx.vin[voteStakeInputIndex].prevout.hash;
+                firstVoteTx = CreateVoteTx( Tip()->GetBlockHash() /* use correct block hash */
+                                          , Tip()->pprev->nHeight /*use prev block height*/
+                                          , ticketHash);
+                b.vtx[1] = MakeTransactionRef(firstVoteTx);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "vote-for-wrong-block");
+    }
+
+    // Attempt to add block with a ticket voting on the correct block height,
+    // but the wrong block hash.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                CMutableTransaction firstVoteTx = *b.vtx[1]; //0 is coinbase
+                const auto& txClass = ParseTxClass(firstVoteTx);
+                BOOST_CHECK_EQUAL(txClass, TX_Vote);
+                const auto& ticketHash = firstVoteTx.vin[voteStakeInputIndex].prevout.hash;
+                firstVoteTx = CreateVoteTx( Tip()->pprev->GetBlockHash() /*use prev block hash*/
+                                          , Tip()->nHeight /*use correct block height*/
+                                          , ticketHash);
+                b.vtx[1] = MakeTransactionRef(firstVoteTx);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "vote-for-wrong-block");
+    }
+    
+    // Attempt to add block with incorrect votebits set.
+    // Everyone votes Yes, but block header says No.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                b.nVoteBits &= ~voteYesBits;
+                // Leaving vote bits as is since all blocks from the generator have
+                // votes set to Yes by default
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "header-votebits-incorrect");
+    }
+
+    // Attempt to add block with incorrect votebits set.
+    // Everyone votes No, but block header says Yes.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                BOOST_CHECK_EQUAL(ConsensusParams().nTicketsPerBlock, 5);
+                b.nVoteBits |= voteYesBits;
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                for (int i = 1; i <= 5; ++i) {
+                    BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[i]), TX_Vote);
+                    ReplaceVoteBits(b.vtx[i],voteNoBits);
+                }
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "header-votebits-incorrect");
+    }
+
+    // Attempt to add block with incorrect votebits set.
+    // 3x No 2x Yes, but block header says Yes.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                BOOST_CHECK_EQUAL(ConsensusParams().nTicketsPerBlock, 5);
+                b.nVoteBits |= voteYesBits;
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                for (int i = 1; i <= 3; ++i) {
+                    BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[i]), TX_Vote);
+                    ReplaceVoteBits(b.vtx[i],voteNoBits);
+                }
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "header-votebits-incorrect");
+    }
+
+    // Attempt to add block with incorrect votebits set.
+    // 2x No 3x Yes, but block header says No.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                BOOST_CHECK_EQUAL(ConsensusParams().nTicketsPerBlock, 5);
+                b.nVoteBits &= ~voteYesBits;
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                for (int i = 1; i <= 2; ++i) {
+                    BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[i]), TX_Vote);
+                    ReplaceVoteBits(b.vtx[i],voteNoBits);
+                }
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "header-votebits-incorrect");
+    }
+
+    // Attempt to add block with incorrect votebits set.
+    // 4x Voters
+    // 2x No 2x Yes, but block header says Yes
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                BOOST_CHECK_EQUAL(ConsensusParams().nTicketsPerBlock, 5);
+                b.nVoteBits |= voteYesBits;
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                for (int i = 1; i <= 2; ++i) {
+                    BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[i]), TX_Vote);
+                    ReplaceVoteBits(b.vtx[i],voteNoBits);
+                }
+                // leave 3 and 4 with Yes
+                // drop the 5th
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[5]), TX_Vote);
+                b.vtx.erase(b.vtx.begin()+5);
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[5]), TX_BuyTicket);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "header-votebits-incorrect");
+    }
+
+    // Attempt to add block with incorrect votebits set.
+    // 3x Voters
+    // 2x No 1x Yes, but block header says Yes
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                BOOST_CHECK_EQUAL(ConsensusParams().nTicketsPerBlock, 5);
+                b.nVoteBits |= voteYesBits;
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                for (int i = 1; i <= 2; ++i) {
+                    BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[i]), TX_Vote);
+                    ReplaceVoteBits(b.vtx[i],voteNoBits);
+                }
+                // leave 1 with Yes
+                // drop the 4th and 5th
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[4]), TX_Vote);
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[5]), TX_Vote);
+                b.vtx.erase(b.vtx.begin()+4,b.vtx.begin()+6);
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[4]), TX_BuyTicket);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "header-votebits-incorrect");
+    }
+
+    // Attempt to add block with incorrect votebits set.
+    // 3x Voters
+    // 1x No 2x Yes, but block header says No
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                BOOST_CHECK_EQUAL(ConsensusParams().nTicketsPerBlock, 5);
+                b.nVoteBits &= ~voteYesBits;
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[1]), TX_Vote);
+                ReplaceVoteBits(b.vtx[1],voteNoBits);
+                // leave 2 with Yes
+                // drop the 4th and 5th
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[4]), TX_Vote);
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[5]), TX_Vote);
+                b.vtx.erase(b.vtx.begin()+4,b.vtx.begin()+6);
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[4]), TX_BuyTicket);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "header-votebits-incorrect");
+    }
+
+    // ---------------------------------------------------------------------
+    // Stake ticket difficulty tests.
+    // ---------------------------------------------------------------------
+
+    // Attempt to add block with a bad ticket purchase commitment.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this, &ticketSpends](CBlock& b) {
+                BOOST_CHECK_EQUAL(ConsensusParams().nTicketsPerBlock, 5);
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[5]), TX_Vote);
+                int idxFirstPurchaseTx = 6;
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[idxFirstPurchaseTx]), TX_BuyTicket);
+
+                // Re-create the purchase tx
+                const auto& ticketPrice = NextRequiredStakeDifficulty();
+                const auto& ticketFee = CAmount(2);
+                auto purchaseTx = CreateTicketPurchaseTx(*ticketSpends.cbegin(),ticketPrice - 1 /* bad commitment */, ticketFee);
+                b.vtx[idxFirstPurchaseTx] = MakeTransactionRef(purchaseTx);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "stake-too-low");
+    }
+
+    // Create block with ticket purchase below required ticket price.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this, &ticketSpends](CBlock& b) {
+                BOOST_CHECK_EQUAL(ConsensusParams().nTicketsPerBlock, 5);
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[5]), TX_Vote);
+
+                auto& firstPurchaseTx = b.vtx[6];
+                BOOST_CHECK_EQUAL(ParseTxClass(*firstPurchaseTx), TX_BuyTicket);
+
+                // Re-create the purchase tx
+                const auto& ticketPrice = NextRequiredStakeDifficulty();
+                const auto& ticketFee = CAmount(2);
+                auto purchaseTx = CreateTicketPurchaseTx(*ticketSpends.cbegin(),ticketPrice, ticketFee);
+                purchaseTx.vout[ticketStakeOutputIndex].nValue--;
+                firstPurchaseTx = MakeTransactionRef(purchaseTx);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "stake-too-low");
+    }
+
+    // Create block with stake transaction below pos limit.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this, &ticketSpends](CBlock& b) {
+                BOOST_CHECK_EQUAL(ConsensusParams().nTicketsPerBlock, 5);
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[5]), TX_Vote);
+
+                auto& firstPurchaseTx = b.vtx[6];
+                BOOST_CHECK_EQUAL(ParseTxClass(*firstPurchaseTx), TX_BuyTicket);
+
+                // Re-create the purchase tx
+                const auto& minimumStakeDiff = ConsensusParams().nMinimumStakeDiff;
+                const auto& ticketFee = CAmount(2);
+                auto purchaseTx = CreateTicketPurchaseTx(*ticketSpends.cbegin(),minimumStakeDiff - 1, ticketFee);
+                purchaseTx.vout[ticketStakeOutputIndex].nValue--;
+                firstPurchaseTx = MakeTransactionRef(purchaseTx);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "stake-too-low");
+    }
+
+    // ---------------------------------------------------------------------
+    // Revocation tests.
+    // ---------------------------------------------------------------------
+    // Create valid block that misses a vote.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                BOOST_CHECK_EQUAL(ConsensusParams().nTicketsPerBlock, 5);
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[1]), TX_Vote);
+                // drop the 5th
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[4]), TX_Vote);
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[5]), TX_Vote);
+                b.vtx.erase(b.vtx.begin()+5);
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[5]), TX_BuyTicket);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() == b.GetHash()); // accepted
+        ticketSpends = OldestCoinOuts();
+    }
+
+    // Create block that has a revocation for a voted ticket.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                BOOST_CHECK_EQUAL(ConsensusParams().nTicketsPerBlock, 5);
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+
+                auto& firstVoteTx = b.vtx[1];
+                BOOST_CHECK_EQUAL(ParseTxClass(*firstVoteTx), TX_Vote);
+                const auto& ticketHashOfFirstVote = firstVoteTx->vin[voteStakeInputIndex].prevout.hash;
+                // create a new revocation for the voted ticket
+                const auto& revocationTx = CreateRevocationTx(ticketHashOfFirstVote);
+                b.vtx.push_back(MakeTransactionRef(revocationTx));
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "bad-ticket-reference-in-revocation");
+    }
+
+    // Create block that has a revocation with more payees than expected.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this, &ticketSpends](CBlock& b) {
+                BOOST_CHECK_EQUAL(ConsensusParams().nTicketsPerBlock, 5);
+
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[5]), TX_Vote);
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[5 + ticketSpends.size()]), TX_BuyTicket);
+
+                auto& firstRevocationTx = b.vtx[5 + ticketSpends.size() + 1];
+                BOOST_CHECK_EQUAL(ParseTxClass(*firstRevocationTx), TX_RevokeTicket);
+
+                // Re create revocation tx
+                const auto& ticketHash = firstRevocationTx->vin[revocationStakeInputIndex].prevout.hash;
+                auto revocationTx = CreateRevocationTx(ticketHash);
+                revocationTx.vout.push_back(revocationTx.vout[0]);
+                firstRevocationTx = MakeTransactionRef(revocationTx);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "bad-revocation-structure");
+    }
+
+    // Create block that has a revocation paying more than the original
+    // amount to the committed address.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this, &ticketSpends](CBlock& b) {
+                BOOST_CHECK_EQUAL(ConsensusParams().nTicketsPerBlock, 5);
+
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[5]), TX_Vote);
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[5 + ticketSpends.size()]), TX_BuyTicket);
+
+                auto& firstRevocationTx = b.vtx[5 + ticketSpends.size() + 1];
+                BOOST_CHECK_EQUAL(ParseTxClass(*firstRevocationTx), TX_RevokeTicket);
+
+                // Re create revocation tx
+                const auto& ticketHash = firstRevocationTx->vin[revocationStakeInputIndex].prevout.hash;
+                auto revocationTx = CreateRevocationTx(ticketHash);
+                revocationTx.vout[revocationRefundOutputIndex].nValue++;
+                firstRevocationTx = MakeTransactionRef(revocationTx);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "revocation-bad-payment-amount");
+    }
+
+    // Create block that has a revocation using a corrupted pay-to-address
+    // script.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends,
+            [this, &ticketSpends](CBlock& b) {
+                BOOST_CHECK_EQUAL(ConsensusParams().nTicketsPerBlock, 5);
+
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[5]), TX_Vote);
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[5 + ticketSpends.size()]), TX_BuyTicket);
+
+                auto& firstRevocationTx = b.vtx[5 + ticketSpends.size() + 1];
+                BOOST_CHECK_EQUAL(ParseTxClass(*firstRevocationTx), TX_RevokeTicket);
+
+                // Re create revocation tx
+                const auto& ticketHash = firstRevocationTx->vin[revocationStakeInputIndex].prevout.hash;
+                auto revocationTx = CreateRevocationTx(ticketHash);
+                revocationTx.vout[revocationRefundOutputIndex].scriptPubKey[8] &= ~0x55; 
+                firstRevocationTx = MakeTransactionRef(revocationTx);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "revocation-incorrect-payment-address");
+    }
+
+    // Create block that contains a revocation due to previous missed vote.
+    {
+        const auto& b = NextBlock("bsm", nullptr, ticketSpends);
+        BOOST_CHECK(Tip()->GetBlockHash() == b.GetHash()); // accepted
+        // check that last one is the revocation
+        BOOST_CHECK_EQUAL(ParseTxClass(**b.vtx.crbegin()), TX_RevokeTicket);
+        // check that the last but one is a purchase
+        BOOST_CHECK_EQUAL(ParseTxClass(**(b.vtx.crbegin()+1)), TX_BuyTicket);
+        ticketSpends = OldestCoinOuts();
+    }
+
+    // ---------------------------------------------------------------------
+    // Stakebase script tests.
+    // ---------------------------------------------------------------------
+
+    // Create block that has a stakebase script that is smaller than the
+    // minimum allowed length.
+    {
+        const auto& b = NextBlock("bss0", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                const auto& tooSmallScript = RepeatOpCode(OP_0, minStakebaseScriptLen - 1);
+                ReplaceStakeBaseSigScript(b.vtx[1], tooSmallScript);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); //rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "bad-stakereward-length");
+    }
+
+    // Create block that has a stakebase script that is larger than the
+    // maximum allowed length.
+    {
+        const auto& b = NextBlock("bss1", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                const auto& tooLargeScript = RepeatOpCode(OP_0, maxStakebaseScriptLen + 1);
+                ReplaceStakeBaseSigScript(b.vtx[1], tooLargeScript);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); //rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "bad-stakereward-length");
+    }
+
+    // Add a block with a stake transaction with a signature script that is
+    // not the required script, but is otherwise a valid script.
+    {
+        const auto& b = NextBlock("bss2", nullptr, ticketSpends,
+            [this](CBlock& b) {
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                auto badScript = Params().GetConsensus().stakeBaseSigScript;
+                badScript << 0x00;
+                ReplaceStakeBaseSigScript(b.vtx[1], badScript);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); //rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "bad-stakereward-scriptsig");
+    }
+
+    // Attempt to add a block with a bad vote payee output.
+    {
+        const auto& b = NextBlock("bss3", nullptr, ticketSpends,
+            [this, &ticketSpends](CBlock& b) {
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[1]), TX_Vote);
+
+                CMutableTransaction voteTx = *b.vtx[1];
+                BOOST_CHECK_EQUAL(ParseTxClass(voteTx),TX_Vote);
+
+                voteTx.vout[voteRewardOutputIndex].scriptPubKey[8] ^= 0x55;
+                b.vtx[1] = MakeTransactionRef(voteTx);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "vote-incorrect-payment-address");
+    }
+
+    // Attempt to add a block with an incorrect vote payee output amount.
+    {
+        const auto& b = NextBlock("bss3", nullptr, ticketSpends,
+            [this, &ticketSpends](CBlock& b) {
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[1]), TX_Vote);
+
+                CMutableTransaction voteTx = *b.vtx[1];
+                BOOST_CHECK_EQUAL(ParseTxClass(voteTx),TX_Vote);
+
+                voteTx.vout[voteRewardOutputIndex].nValue++;
+                b.vtx[1] = MakeTransactionRef(voteTx);
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash()); // rejected
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "vote-bad-payment-amount");
+    }
+
+    // ---------------------------------------------------------------------
+    // Disapproval tests.
+    // ---------------------------------------------------------------------
+
+    // Add a block which will be disapproved 
+    auto spendableOutFromDisapprovedBlock = SpendableOut{};
+    {
+        const auto& b = NextBlock("bdsp1", &*ticketSpends.cbegin(), {});
+        BOOST_CHECK(Tip()->GetBlockHash() == b.GetHash()); // accepted
+        // index of the spendtx is 6, it is after the coinbase(0) and the votetx([1-5])
+        spendableOutFromDisapprovedBlock = MakeSpendableOut(*b.vtx[6],0);
+    }
+
+    // Attempt to add block with a ticket purchase using output from
+    // disapproved block.
+    {
+        const auto& b = NextBlock("bsm", nullptr, {spendableOutFromDisapprovedBlock},
+            [this](CBlock& b) {
+                BOOST_CHECK_EQUAL(ConsensusParams().nTicketsPerBlock, 5);
+                // Header says No and all vote say No
+                b.nVoteBits &= ~voteYesBits;
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                for(int i = 1; i <= 5; ++i)
+                {
+                    BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[i]), TX_Vote);
+                    ReplaceVoteBits(b.vtx[i],voteNoBits);
+                }
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash());
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "bad-txns-inputs-missingorspent");
+    }
+
+    // create another block to be disapproved
+    {
+        const auto& b = NextBlock("bdsp2", &*ticketSpends.cbegin(), {});
+        BOOST_CHECK(Tip()->GetBlockHash() == b.GetHash()); // accepted
+        // index of the spendtx is 6, it is after the coinbase(0) and the votetx([1-5])
+        spendableOutFromDisapprovedBlock = MakeSpendableOut(*b.vtx[6],0);
+    }
+
+    // Attempt to add block with a regular transaction using output
+    // from disapproved block.
+    {
+        const auto& b = NextBlock("bsm", &spendableOutFromDisapprovedBlock, {},
+            [this](CBlock& b) {
+                BOOST_CHECK_EQUAL(ConsensusParams().nTicketsPerBlock, 5);
+                // Header says No and all vote say No
+                b.nVoteBits &= ~voteYesBits;
+                BOOST_CHECK(b.vtx[0]->IsCoinBase());
+                for(int i = 1; i <= 5; ++i)
+                {
+                    BOOST_CHECK_EQUAL(ParseTxClass(*b.vtx[i]), TX_Vote);
+                    ReplaceVoteBits(b.vtx[i],voteNoBits);
+                }
+            }
+        );
+        BOOST_CHECK(Tip()->GetBlockHash() != b.GetHash());
+        BOOST_CHECK_EQUAL(LastValidationState().GetRejectReason(), "bad-txns-inputs-missingorspent");
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/test_paicoin.cpp
+++ b/src/test/test_paicoin.cpp
@@ -197,7 +197,7 @@ Generator::~Generator()
     ;
 }
 
-void Generator::SignTx(CMutableTransaction& tx, unsigned int nIn, const CScript& script, const CKey& key)
+void Generator::SignTx(CMutableTransaction& tx, unsigned int nIn, const CScript& script, const CKey& key) const
 {
     std::vector<unsigned char> vchSig;
     uint256 hash = SignatureHash(script, tx, nIn, SIGHASH_ALL, 0, SIGVERSION_BASE);
@@ -237,28 +237,26 @@ CMutableTransaction Generator::CreateTicketPurchaseTx(const SpendableOut& spend,
     return mtx;
 }
     
-CMutableTransaction Generator::CreateVoteTx(const CBlockIndex& voteBlock, const uint256& ticketTxHash)
+CMutableTransaction Generator::CreateVoteTx(const uint256& voteBlockHash, int voteBlockHeight, const uint256& ticketTxHash, uint32_t voteBits) const
 {
     CMutableTransaction mtx;
 
-    const auto& voterSubsidy = GetVoterSubsidy(voteBlock.nHeight+1/*spend height*/,Params().GetConsensus());
-    const auto& ticketPrice  = boughtTicketHashToPrice[ticketTxHash];
+    const auto& voterSubsidy = GetVoterSubsidy(voteBlockHeight+1/*spend height*/,Params().GetConsensus());
+    const auto& ticketPrice  = boughtTicketHashToPrice.at(ticketTxHash);
     const auto& contributedAmount = ticketPrice + 2 /*fee*/;
     const auto& reward = CalcContributorRemuneration( contributedAmount, ticketPrice, voterSubsidy, contributedAmount);
     // create a reward generation input
-    mtx.vin.push_back(CTxIn(COutPoint(), CScript() << 55 << OP_0/*added to avoid bad-stakereward-length; TODO set correct script*/));
+    mtx.vin.push_back(CTxIn(COutPoint(), Params().GetConsensus().stakeBaseSigScript));
 
     mtx.vin.push_back(CTxIn(COutPoint(ticketTxHash, ticketStakeOutputIndex)));
 
     // create a structured OP_RETURN output containing tx declaration and voting data
-    uint32_t voteYesBits = 0x0001;
     int voteVersion = 1;
-    VoteData voteData = { voteVersion, voteBlock.GetBlockHash(), static_cast<uint32_t>(voteBlock.nHeight), voteYesBits };
+    VoteData voteData = { voteVersion, voteBlockHash, static_cast<uint32_t>(voteBlockHeight), voteBits };
     CScript declScript = GetScriptForVoteDecl(voteData);
     mtx.vout.push_back(CTxOut(0, declScript));
 
-    // Create an output which pays back a dummy reward
-    CScript rewardScript = GetScriptForDestination(rewardAddr);
+    // Create an output which pays back a reward
     mtx.vout.push_back(CTxOut(reward, rewardScript));
 
     SignTx(mtx, voteStakeInputIndex, stakeScript, coinbaseKey);
@@ -266,7 +264,7 @@ CMutableTransaction Generator::CreateVoteTx(const CBlockIndex& voteBlock, const 
     return mtx;
 }
 
-CMutableTransaction Generator::CreateRevocationTx(const uint256& ticketTxHash)
+CMutableTransaction Generator::CreateRevocationTx(const uint256& ticketTxHash) const
 {
     CMutableTransaction mtx;
 
@@ -279,8 +277,7 @@ CMutableTransaction Generator::CreateRevocationTx(const uint256& ticketTxHash)
     mtx.vout.push_back(CTxOut(0, declScript));
 
     // Create an output which pays back ticket price as a refund
-    CScript rewardScript = GetScriptForDestination(rewardAddr);
-    const auto& ticketPrice  = boughtTicketHashToPrice[ticketTxHash]; 
+    const auto& ticketPrice  = boughtTicketHashToPrice.at(ticketTxHash); 
     mtx.vout.push_back(CTxOut(ticketPrice, rewardScript));
 
     SignTx(mtx, revocationStakeInputIndex, stakeScript, coinbaseKey);
@@ -288,7 +285,7 @@ CMutableTransaction Generator::CreateRevocationTx(const uint256& ticketTxHash)
     return mtx;
 }
 
-CMutableTransaction Generator::CreateSpendTx(const SpendableOut& spend, const CAmount& fee)
+CMutableTransaction Generator::CreateSpendTx(const SpendableOut& spend, const CAmount& fee) const
 {
     CMutableTransaction mtx;
     // create input to fund the transaction
@@ -303,7 +300,7 @@ CMutableTransaction Generator::CreateSpendTx(const SpendableOut& spend, const CA
     return mtx;
 }
 
-CMutableTransaction Generator::CreateSplitSpendTx(const SpendableOut& spend, const std::vector<CAmount>& payments, const CAmount& fee)
+CMutableTransaction Generator::CreateSplitSpendTx(const SpendableOut& spend, const std::vector<CAmount>& payments, const CAmount& fee) const
 {
     CMutableTransaction mtx;
     // create input to fund the transaction
@@ -351,7 +348,7 @@ void Generator::SaveAllSpendableOuts(const CBlock& b)
             const auto& txClass = ParseTxClass(*tx);
             switch(txClass){
             case TX_Regular:
-                for (int i = 0; i < tx->vout.size(); ++i) { 
+                for (size_t i = 0; i < tx->vout.size(); ++i) { 
                     outs.push_back(MakeSpendableOut(*tx, i));
                 }
                 break;
@@ -367,7 +364,7 @@ void Generator::SaveAllSpendableOuts(const CBlock& b)
     spendableOuts.push_back(outs);
 }
 
-Generator::SpendableOut Generator::MakeSpendableOut(const CTransaction& tx, uint32_t indexOut)
+Generator::SpendableOut Generator::MakeSpendableOut(const CTransaction& tx, uint32_t indexOut) const
 {
     return Generator::SpendableOut{COutPoint{tx.GetHash(), indexOut}, Tip()->nHeight, tx.vout[indexOut].nValue};
 }
@@ -379,22 +376,50 @@ std::list<Generator::SpendableOut> Generator::OldestCoinOuts()
     return oldest;
 }
 
-const CBlockIndex* Generator::Tip()
+const CBlockIndex* Generator::Tip() const
 {
     const auto& tip = chainActive.Tip();
     return tip;
 }
 
-const Consensus::Params& Generator::ConsensusParams()
+const Consensus::Params& Generator::ConsensusParams() const
 {
     return Params().GetConsensus();
 }
 
-CAmount Generator::NextRequiredStakeDifficulty()
+CAmount Generator::NextRequiredStakeDifficulty() const
 {
     CBlock dummyBlock;
     const auto& ticketPrice = calcNextRequiredStakeDifficulty(dummyBlock, chainActive.Tip(), Params());
     return ticketPrice;
+}
+
+void Generator::ReplaceVoteBits(CTransactionRef& tx, uint32_t voteBits) const
+{
+    // Regenerate vote tx using the same hash/height, but change the voteBits
+    CMutableTransaction voteTx = *tx;
+    assert(ParseTxClass(voteTx)==TX_Vote);
+    const auto& ticketHash = voteTx.vin[voteStakeInputIndex].prevout.hash;
+    voteTx = CreateVoteTx(Tip()->GetBlockHash(), Tip()->nHeight, ticketHash, voteBits);
+    tx = MakeTransactionRef(voteTx);
+}
+
+void Generator::ReplaceStakeBaseSigScript(CTransactionRef& tx, const CScript& sigScript) const
+{
+    CMutableTransaction voteTx = *tx;
+    assert(ParseTxClass(voteTx)==TX_Vote);
+    voteTx.vin[voteSubsidyInputIndex].scriptSig = sigScript;
+    tx = MakeTransactionRef(voteTx);
+}
+
+CScript Generator::RepeatOpCode(opcodetype opCode, uint16_t numRepeats) const
+{
+    auto result = CScript();
+    for(auto i = 0u ; i < numRepeats; ++i)
+    {
+        result << opCode;
+    }
+    return result;
 }
 
 CBlock Generator::NextBlock(const std::string& blockName
@@ -406,7 +431,7 @@ CBlock Generator::NextBlock(const std::string& blockName
     const Consensus::Params& params = chainparams.GetConsensus();
 
     TestMemPoolEntryHelper entry;
-    const auto& nextHeight = chainActive.Tip()->nHeight + 1;
+    const auto& nextHeight = Tip()->nHeight + 1;
 
     mempool.clear();
 
@@ -416,8 +441,10 @@ CBlock Generator::NextBlock(const std::string& blockName
         if (nextHeight >= params.nStakeValidationHeight){
             // Generate and add the vote transactions for the winning tickets
             const auto& winners = chainActive.Tip()->pstakeNode->Winners();
+            const auto& voteBlockHash = Tip()->GetBlockHash();
+            const auto& voteBlockHeight = Tip()->nHeight;
             for (const auto& ticket: winners) {
-                const auto& voteTx = CreateVoteTx(*chainActive.Tip(), ticket);
+                const auto& voteTx = CreateVoteTx(voteBlockHash, voteBlockHeight, ticket);
                 mempool.addUnchecked(voteTx.GetHash(), entry.Fee(0LL).SpendsCoinbase(false).FromTx(voteTx));
             }
         }
@@ -451,12 +478,9 @@ CBlock Generator::NextBlock(const std::string& blockName
     CBlock& block = pblocktemplate->block;
 
     if (munger){
-        // Replace mempool-selected txns with just coinbase plus the txns done in munger:
         mempool.clear();
-        const auto& mungerTxs = munger(block);
-        block.vtx.resize(1);
-        for (const CMutableTransaction& tx : mungerTxs)
-            block.vtx.push_back(MakeTransactionRef(tx));
+        // calling the munger which can change the block
+        munger(block);
     }
 
     // IncrementExtraNonce creates a valid coinbase and merkleRoot
@@ -466,7 +490,17 @@ CBlock Generator::NextBlock(const std::string& blockName
     while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 
     std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(block);
-    ProcessNewBlock(chainparams, shared_pblock, true, nullptr);
+    submitblock_StateCatcher sc(shared_pblock->GetHash());
+    RegisterValidationInterface(&sc);
+    const auto bAccepted = ProcessNewBlock(chainparams, shared_pblock, true, nullptr);
+    UnregisterValidationInterface(&sc);
+    if (!bAccepted || sc.found)
+    {
+        lastValidationState = sc.state;
+    }
+    else {
+        lastValidationState = CValidationState{};
+    }
 
     CBlock result = block;
     return result;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1632,7 +1632,7 @@ int ApplyTxInUndo(Coin&& undo, CCoinsViewCache& view, const COutPoint& out)
 
 /** Undo the effects of this block (with given index) on the UTXO set represented by coins.
  *  When FAILED is returned, view is left in an indeterminate state. */
-static DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view)
+static DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* pindex, CCoinsViewCache& view, bool bOnlyDisconnectRegularTxs = false)
 {
     bool fClean = true;
 
@@ -1660,13 +1660,19 @@ static DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* 
     //         return DISCONNECT_FAILED;
     //     }
     // }
-    //TODO use the read StakeNode info
+    //TODO use the read StakeNode info, in case only Regular transactions are disconnected we won't need to do it
 
     // undo transactions in reverse order
     for (int i = block.vtx.size() - 1; i >= 0; i--) {
         const CTransaction &tx = *(block.vtx[i]);
+
         uint256 hash = tx.GetHash();
         bool is_coinbase = tx.IsCoinBase();
+
+        if (!is_coinbase && bOnlyDisconnectRegularTxs) {
+            const auto& txClass = ParseTxClass(tx);
+            if (txClass != TX_Regular) continue;
+        }
 
         // Check that all outputs are available and match the outputs in the block itself
         // exactly.
@@ -1698,10 +1704,40 @@ static DisconnectResult DisconnectBlock(const CBlock& block, const CBlockIndex* 
         }
     }
 
-    // move best block pointer to prevout block
-    view.SetBestBlock(pindex->pprev->GetBlockHash());
+    if (!bOnlyDisconnectRegularTxs) {
+        // move best block pointer to prevout block
+        view.SetBestBlock(pindex->pprev->GetBlockHash());
+    }
 
     return fClean ? DISCONNECT_OK : DISCONNECT_UNCLEAN;
+}
+
+static bool DisconnectDisapprovedTip(CValidationState& state, const CChainParams& chainparams, DisconnectedBlockTransactions *disconnectpool)
+{
+    CBlockIndex *pindexDisapproved = chainActive.Tip();
+    assert(pindexDisapproved);
+    // Read block from disk.
+    std::shared_ptr<CBlock> pblock = std::make_shared<CBlock>();
+    CBlock& block = *pblock;
+    if (!ReadBlockFromDisk(block, pindexDisapproved, chainparams.GetConsensus()))
+        return AbortNode(state, "Failed to read block");
+    CCoinsViewCache view(pcoinsTip);
+    assert(view.GetBestBlock() == pindexDisapproved->GetBlockHash());
+    if (DisconnectBlock(block, pindexDisapproved, view, true /*bOnlyDisconnectRegularTxs*/) != DISCONNECT_OK)
+        return error("DisconnectDisapprovedTip(): DisconnectBlock %s failed", pindexDisapproved->GetBlockHash().ToString());
+    bool flushed = view.Flush();
+    assert(flushed);
+
+    assert (disconnectpool != nullptr);
+
+    for ( auto it = block.vtx.crbegin(); it != block.vtx.crend(); ++it ) {
+        if (TX_Regular == ParseTxClass(**it))
+            disconnectpool->addTransaction(*it);
+        else // once we find a stake transaction we can break, we want to skip all stake txs and coinbase
+            break;
+    }
+
+    return true;
 }
 
 void static FlushBlockFile(bool fFinalize = false)
@@ -1965,6 +2001,16 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
         nLockTimeFlags |= LOCKTIME_VERIFY_SEQUENCE;
     }
 
+    if (pindex->nHeight > 1 && pindex->nVoteBits != 1) {
+        DisconnectedBlockTransactions disconnectedPool;
+        if (!DisconnectDisapprovedTip(state,chainparams, &disconnectedPool)){
+            UpdateMempoolForReorg(disconnectedPool, false);
+        }
+        else {
+            UpdateMempoolForReorg(disconnectedPool, true); //add the disconnected back to mempool
+        }
+    }
+
     // Get the script flags for this block
     unsigned int flags = GetBlockScriptFlags(pindex, chainparams.GetConsensus());
 
@@ -2099,7 +2145,8 @@ static bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockInd
         setDirtyBlockIndex.insert(pindex);
     }
 
-    // auto stakeNode = *FetchStakeNode(pindex, chainparams.GetConsensus());
+    // we may try to connect the stakenode as all checks were done, including tx checks
+    pindex->pstakeNode = FetchStakeNode(pindex,chainparams.GetConsensus());
     if(pindex->GetStakePos().IsNull()){
         CDiskBlockPos _pos;
 
@@ -3155,21 +3202,21 @@ bool CheckBlock(const CBlock& block, CValidationState& state, const Consensus::P
 
     // Before stake validation begins, a block must not contain any votes or revocations, its vote bits
     // must be 0x0001, and its ticket lottery state must be all zeroes.
-    // if (nBlockHeight < consensusParams.nStakeValidationHeight) {
-    //     if (numVotes > 0)
-    //         return state.DoS(50, false, REJECT_INVALID, "votes-too-early", false, "vote transactions present before stake validation time");
+    if (blockHeight < consensusParams.nStakeValidationHeight) {
+        if (numVotes > 0)
+            return state.DoS(50, false, REJECT_INVALID, "votes-too-early", false, "vote transactions present before stake validation time");
 
-    //     if (numRevocations > 0)
-    //         return state.DoS(50, false, REJECT_INVALID, "revocations-too-early", false, "revocation transactions present before stake validation time");
+        if (numRevocations > 0)
+            return state.DoS(50, false, REJECT_INVALID, "revocations-too-early", false, "revocation transactions present before stake validation time");
 
-    //     if (block.nVoteBits != 1)   // before stake validation height, blocks must all have voteBits set to 1 (simple approval)
-    //         return state.DoS(50, false, REJECT_INVALID, "voteBits-too-early", false, "voteBits present before stake validation time");
+        if (block.nVoteBits != 1)   // before stake validation height, blocks must all have voteBits set to 1 (simple approval)
+            return state.DoS(50, false, REJECT_INVALID, "voteBits-too-early", false, "voteBits present before stake validation time");
 
-    //     StakeState earlyLotteryState;
-    //     std::fill(earlyLotteryState.begin(), earlyLotteryState.end(), 0);
-    //     if (block.ticketLotteryState != earlyLotteryState)
-    //         return state.DoS(50, false, REJECT_INVALID, "lottery-too-early", false, "ticket lottery state non-zero before stake validation time");
-    // }
+        StakeState earlyLotteryState;
+        std::fill(earlyLotteryState.begin(), earlyLotteryState.end(), 0);
+        if (block.ticketLotteryState != earlyLotteryState)
+            return state.DoS(50, false, REJECT_INVALID, "lottery-too-early", false, "ticket lottery state non-zero before stake validation time");
+    }
 
     // Check that the number of votes in a block is within limits
     if (blockHeight >= consensusParams.nStakeValidationHeight)
@@ -3717,9 +3764,6 @@ static bool AcceptBlock(const std::shared_ptr<const CBlock>& pblock, CValidation
 
     if (pindex->pprev == nullptr) {
         pindex->pstakeNode = StakeNode::genesisNode(chainparams.GetConsensus());
-    }
-    else{
-        pindex->pstakeNode = FetchStakeNode(pindex, chainparams.GetConsensus() );
     }
 
     return true;


### PR DESCRIPTION
…ehavior for disproved blocks

* changed the Generator to catch the validation state to be able to check it
* added generic vote and vote-for-wrong-block scenarios
* refactored the mungers to allow block changes and some of them
* added revocation scenarios
* moved call to FetchStakeNode in ConnectBlock to fix revocations tests
* added support for block disproval scenarios (implement DisconnectDisapprobedBlock and add back disconnected regular txs in mempool)
* added stakebase scenarios