### PR TITLE
Issues #54: Review and complete implementation of stake RPC calls

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -324,6 +324,8 @@ libpaicoin_consensus_a_SOURCES = \
   stake/stakenode.h \
   stake/staketx.cpp \
   stake/staketx.h \
+  stake/stakeversion.cpp \
+  stake/stakeversion.h \
   tinyformat.h \
   uint256.cpp \
   uint256.h \

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -112,6 +112,11 @@ CBlockIndex* CBlockIndex::GetAncestor(int height)
     return const_cast<CBlockIndex*>(static_cast<const CBlockIndex*>(this)->GetAncestor(height));
 }
 
+const CBlockIndex* CBlockIndex::GetRelativeAncestor(int distance) const
+{
+    return GetAncestor(nHeight - distance);
+}
+
 void CBlockIndex::BuildSkip()
 {
     if (pprev)

--- a/src/chain.h
+++ b/src/chain.h
@@ -227,6 +227,7 @@ public:
     uint32_t nTicketPoolSize;
     StakeState ticketLotteryState;
     uint8_t nFreshStake;
+    uint32_t nStakeVersion;
 
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     int32_t nSequenceId;
@@ -268,6 +269,7 @@ public:
         nTicketPoolSize = 0;
         std::fill(ticketLotteryState.begin(), ticketLotteryState.end(), 0);
         nFreshStake = 0;
+        nStakeVersion  = 0;
     }
 
     CBlockIndex()
@@ -288,7 +290,8 @@ public:
         nVoteBits      = block.nVoteBits;
         nTicketPoolSize = block.nTicketPoolSize;
         ticketLotteryState = block.ticketLotteryState;
-        nFreshStake = block.nFreshStake;
+        nFreshStake    = block.nFreshStake;
+        nStakeVersion  = block.nStakeVersion;
     }
 
     CDiskBlockPos GetBlockPos() const {
@@ -333,6 +336,7 @@ public:
         block.nTicketPoolSize = nTicketPoolSize;
         block.ticketLotteryState = ticketLotteryState;
         block.nFreshStake = nFreshStake;
+        block.nStakeVersion = nStakeVersion;
         return block;
     }
 
@@ -408,6 +412,7 @@ public:
     //! Efficiently find an ancestor of this block.
     CBlockIndex* GetAncestor(int height);
     const CBlockIndex* GetAncestor(int height) const;
+    const CBlockIndex* GetRelativeAncestor(int distance) const;
 
     void PopulateTicketInfo(const SpentTicketsInBlock& spentTicketsInBlock);
 };
@@ -474,7 +479,8 @@ public:
         block.nVoteBits       = nVoteBits;
         block.nTicketPoolSize = nTicketPoolSize;
         block.ticketLotteryState = ticketLotteryState;
-        block.nFreshStake = nFreshStake;
+        block.nFreshStake     = nFreshStake;
+        block.nStakeVersion   = nStakeVersion;
         return block.GetHash();
     }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -77,6 +77,7 @@ static CBlock CreateGenesisBlock(const char* pszTimestamp, const CScript& genesi
     genesis.nVoteBits = 1;
     genesis.nTicketPoolSize = 0;
     std::fill(genesis.ticketLotteryState.begin(), genesis.ticketLotteryState.end(), 0);
+    genesis.nStakeVersion = 0;
     genesis.nNonce   = nNonce;
     genesis.nVersion = nVersion;
     genesis.vtx.push_back(MakeTransactionRef(std::move(txNew)));
@@ -265,7 +266,7 @@ public:
         consensus.nStakeDiffAlpha              = 1;
         consensus.nStakeDiffWindowSize         = 144;
         consensus.nStakeDiffWindows            = 20;
-        consensus.nStakeVersionInterval        = 144 * 2 * 7; // ~1 week
+        consensus.nStakeVersionInterval        = 144 * 2 * 7; // ~2 weeks
         consensus.nMaxFreshStakePerBlock       = 4 * consensus.nTicketsPerBlock;
         consensus.nStakeEnabledHeight          = consensus.nCoinbaseMaturity + consensus.nTicketMaturity;
         consensus.nStakeValidationHeight       = 4096;        // ~ 14 days
@@ -423,10 +424,10 @@ public:
         consensus.nStakeDiffAlpha              = 1;
         consensus.nStakeDiffWindowSize         = 144;
         consensus.nStakeDiffWindows            = 20;
-        consensus.nStakeVersionInterval        = 144 * 2 * 7; // ~1 week
+        consensus.nStakeVersionInterval        = 144 * 2 * 7; // ~2 weeks
         consensus.nMaxFreshStakePerBlock       = 4 * consensus.nTicketsPerBlock;
         consensus.nStakeEnabledHeight          = consensus.nCoinbaseMaturity + consensus.nTicketMaturity;
-        consensus.nStakeValidationHeight       = 100000;      // Arbitrary chosen into the future; height is 46261 at the moment
+        consensus.nStakeValidationHeight       = 768;//100000;      // Arbitrary chosen into the future; height is 46261 at the moment
         consensus.stakeBaseSigScript           = CScript() << 0x00 << 0x00;
         consensus.nStakeMajorityMultiplier     = 3;
         consensus.nStakeMajorityDivisor        = 4;
@@ -565,7 +566,7 @@ public:
         consensus.nStakeDiffAlpha              = 1;
         consensus.nStakeDiffWindowSize         = 8;
         consensus.nStakeDiffWindows            = 8;
-        consensus.nStakeVersionInterval        = 8 * 2 * 7; // ~1 week
+        consensus.nStakeVersionInterval        = 6 * 24; // ~1 day
         consensus.nMaxFreshStakePerBlock       = 4 * consensus.nTicketsPerBlock;
         consensus.nStakeEnabledHeight          = 2000;//141;//consensus.nCoinbaseMaturity + consensus.nTicketMaturity;
         consensus.nStakeValidationHeight       = 2100;//200;//consensus.nCoinbaseMaturity + (consensus.nTicketPoolSize * 2);

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -122,11 +122,11 @@ struct Params {
     uint8_t nMaxFreshStakePerBlock;
     // StakeEnabledHeight is the height in which the first ticket could possibly
     // mature.
-    int64_t nStakeEnabledHeight;
+    int32_t nStakeEnabledHeight;
     // StakeValidationHeight is the height at which votes (SSGen) are required
     // to add a new block to the top of the blockchain. This height is the
     // first block that will be voted on, but will include in itself no votes.
-    int64_t nStakeValidationHeight;
+    int32_t nStakeValidationHeight;
     // StakeBaseSigScript is the consensus stakebase signature script for all
     // votes on the network. This isn't signed in any way, so without forcing
     // it to be this value miners/daemons could freely change it.

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -400,6 +400,10 @@ bool checkVoteOrRevokeTicketInputs(const CTransaction& tx, bool vote, CValidatio
         CTxDestination dest;
         if (!ExtractDestination(tx.vout[i].scriptPubKey, dest) || !IsValidDestination(dest))
             return state.DoS(100, false, REJECT_INVALID, what + "-invalid-payment-address");
+        
+        if (dest.which() != contrib.whichAddr)
+            return state.DoS(100, false, REJECT_INVALID, what + "-incorrect-address-type");
+
         const uint160& addr = dest.which() == 1 ? boost::get<CKeyID>(dest) : boost::get<CScriptID>(dest);
         if (addr != contrib.rewardAddr)
             return state.DoS(100, false, REJECT_INVALID, what + "-incorrect-payment-address");

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -129,7 +129,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     nHeight = pindexPrev->nHeight + 1;
 
     pblock->nVersion = ComputeBlockVersion(pindexPrev, chainparams.GetConsensus());
-    pblock->nStakeDifficulty = calcNextRequiredStakeDifficulty(*pblock,pindexPrev,chainparams);
+    pblock->nStakeDifficulty = CalculateNextRequiredStakeDifficulty(pindexPrev,chainparams.GetConsensus());
     if (pindexPrev->pstakeNode != nullptr) {
         pblock->ticketLotteryState = pindexPrev->pstakeNode->FinalState();
         pblock->nTicketPoolSize = pindexPrev->pstakeNode->PoolSize();

--- a/src/pow.h
+++ b/src/pow.h
@@ -60,4 +60,21 @@ int64_t EstimateSupply(const Consensus::Params&, int64_t height);
 
 CAmount GetTotalBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);
 
+// estimateNextStakeDifficulty estimates the next stake difficulty by pretending
+// the provided number of tickets will be purchased in the remainder of the
+// interval unless the flag to use max tickets is set in which case it will use
+// the max possible number of tickets that can be purchased in the remainder of
+// the interval.
+//
+// The stake difficulty algorithm is selected based on the active rules.
+//
+// This function differs from the exported EstimateNextStakeDifficulty in that
+// the exported version uses the current best chain as the block node while this
+// function accepts any block node.
+//
+// This function MUST be called with the chain state lock held (for writes).
+
+// Note: only the newer algorithm estimateNextStakeDifficultyV2 is ported
+int64_t EstimateNextStakeDifficulty(const CBlockIndex* pindexLast, int newTickets, bool useMaxTickets, const Consensus::Params& params);
+
 #endif // PAICOIN_POW_H

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -23,14 +23,14 @@ std::string CBlock::ToString() const
     std::stringstream s;
     s << strprintf("CBlock(hash=%s, ver=0x%08x, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, "
                    "nStakeDifficulty=%s, nVoteBits=%08x, nTicketPoolSize=%u, ticketLotteryState=%s,"
-                   "nFreshStake=%u, vtx=%u)\n",
+                   "nFreshStake=%u, nStakeVersion=%u, vtx=%u)\n",
         GetHash().ToString(),
         nVersion,
         hashPrevBlock.ToString(),
         hashMerkleRoot.ToString(),
         nTime, nBits, nNonce,
         std::to_string(nStakeDifficulty), nVoteBits, nTicketPoolSize, StakeStateToString(ticketLotteryState),
-        nFreshStake, vtx.size());
+        nFreshStake,  nStakeVersion, vtx.size());
     for (const auto& tx : vtx) {
         s << "  " << tx->ToString() << "\n";
     }

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -34,7 +34,7 @@ public:
     uint32_t nTicketPoolSize;
     uint48  ticketLotteryState;
     uint8_t nFreshStake;
-
+    uint32_t nStakeVersion;
 
     CBlockHeader()
     {
@@ -51,6 +51,12 @@ public:
         READWRITE(nTime);
         READWRITE(nBits);
         READWRITE(nNonce);
+        // TODO: serialization of stake fields to activate when Hybrid PoW/PoS deploys
+//        READWRITE(nStakeDifficulty);
+//        READWRITE(nVoteBits);
+//        READWRITE(nTicketPoolSize);
+//        READWRITE(ticketLotteryState);
+//        READWRITE(nStakeVersion);
     }
 
     void SetNull()
@@ -66,6 +72,7 @@ public:
         nTicketPoolSize = 0;
         std::fill(ticketLotteryState.begin(), ticketLotteryState.end(), 0);
         nFreshStake = 0;
+        nStakeVersion = 0;
     }
 
     bool IsNull() const
@@ -130,7 +137,8 @@ public:
         block.nStakeDifficulty = nStakeDifficulty;
         block.nTicketPoolSize = nTicketPoolSize;
         block.ticketLotteryState = ticketLotteryState;
-        block.nFreshStake = nFreshStake;
+        block.nFreshStake    = nFreshStake;
+        block.nStakeVersion  = nStakeVersion;
         return block;
     }
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -679,6 +679,7 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     result.push_back(Pair("votebits", strprintf("%08x", pblock->nVoteBits)));
     result.push_back(Pair("ticketpoolsize", strprintf("%08x", pblock->nTicketPoolSize)));
     result.push_back(Pair("ticketlotterystate", StakeStateToString(pblock->ticketLotteryState)));
+    result.push_back(Pair("stakeversion", strprintf("%08x", pblock->nStakeVersion)));
     result.push_back(Pair("height", static_cast<int64_t>((pindexPrev->nHeight+1))));
     result.push_back(Pair("freshstake", pblock->nFreshStake));
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -176,9 +176,8 @@ UniValue existsmempooltxs(const JSONRPCRequest& request)
 
     for (auto txIdx = 0u; txIdx < numTxs; ++txIdx, hashIt += 64) {
         std::string txhash(hashIt, hashIt + 64);
-        auto txHashChars = ParseHex(txhash);
+        const auto& txHash = uint256S(txhash);
 
-        uint256 txHash(txHashChars);
         auto txExists = mempool.exists(txHash);
         existsMemPoolTxs[txIdx] = txExists ? 1 : 0;
     }

--- a/src/rpc/stakeapi.cpp
+++ b/src/rpc/stakeapi.cpp
@@ -10,29 +10,75 @@
 #include "sync.h"
 #include "utilstrencodings.h"
 #include "validation.h"
+#include "pow.h"
+#include "stake/stakeversion.h"
 
 #include <stdint.h>
 #include <univalue.h>
+
+// StakeVersions is a condensed form of a dcrutil.Block that is used to prevent
+// using gigabytes of memory.
+struct StakeVersions {
+    uint256 hash;
+    int height;
+    int32_t blockVersion;
+    uint32_t stakeVersion;
+    VoteVersionVector votes;
+};
+
+
+std::vector<StakeVersions> GetStakeVersions(const CBlockIndex* const startIndex, int count)
+{
+    if (startIndex == nullptr){
+        throw JSONRPCError(RPCErrorCode::INVALID_PARAMETER, "Invalid block index.");
+    }
+    auto result = std::vector<StakeVersions>{};
+    // Nothing to do if no count requested.
+    if (count == 0) {
+        return result;
+    }
+    if (count < 0) {
+        throw JSONRPCError(RPCErrorCode::INVALID_PARAMETER, "Invalid count, must be greater than zero");
+    }
+    // Limit the requested count to the max possible for the requested block.
+    if (count > startIndex->nHeight + 1) {
+        count = startIndex->nHeight + 1;
+    }
+
+    auto prevIndex = startIndex;
+    for (auto i = 0; prevIndex != nullptr && i < count; i++) {
+        result.push_back(StakeVersions{
+            prevIndex->GetBlockHash(),
+            prevIndex->nHeight,
+            prevIndex->nVersion,
+            prevIndex->nStakeVersion,
+            prevIndex->votes});
+        prevIndex = prevIndex->pprev;
+    }
+
+    return result;
+};
 
 UniValue estimatestakediff(const JSONRPCRequest& request)
 {
     if (request.fHelp || request.params.size() > 1)
         throw std::runtime_error(
             "estimatestakediff \"numtickets\"\n"
-            "\nEstimate the stake difficulty.\n"
+            "\nEstimate the next minimum, maximum, expected, and user-specified stake difficulty.\n"
             "\nArguments:\n"
-            "1. \"numtickets\"   (integer, optional) The custom number of tickets\n"
+            "1. \"numtickets\"   (integer, optional) Use this number of new tickets in blocks to estimate the next difficulty\n"
             "\nResult:\n"
             "\"min\"             (numeric) Minimum estimate for stake difficulty\n"
             "\"max\"             (numeric) Maximum estimate for stake difficulty\n"
             "\"expected\"        (numeric) Expected estimate for stake difficulty\n"
-            "\"user\"            (numeric, optional) Estimate for stake difficulty with the passed user amount of tickets\n"
+            "\"user\"            (numeric) Estimate for stake difficulty with the passed user amount of tickets\n"
             "\nExample:\n"
             "\nEstimate stake difficulty\n"
             + HelpExampleCli("estimatestakediff", "1")
         );
 
-    auto userTickets = false;
+    const auto& params = Params().GetConsensus();
+    auto userEstimate = int64_t{0};
     if (!request.params.empty() && !request.params[0].isNull()) {
         RPCTypeCheck(request.params, {UniValue::VNUM});
 
@@ -40,17 +86,40 @@ UniValue estimatestakediff(const JSONRPCRequest& request)
         if (ticketsValue < 0) {
             throw JSONRPCError(RPCErrorCode::INVALID_PARAMETER, "Invalid number of tickets");
         }
-        userTickets = true;
+        // User-specified stake difficulty, if they asked for one.
+        LOCK(cs_main);
+        userEstimate = EstimateNextStakeDifficulty(chainActive.Tip(), ticketsValue, false, params);
     }
+
+    // Minimum possible stake difficulty.
+    LOCK(cs_main);
+    const auto& min = EstimateNextStakeDifficulty(chainActive.Tip(), 0, false, params);
+
+    // Maximum possible stake difficulty.
+    const auto& max = EstimateNextStakeDifficulty(chainActive.Tip(), 0, true, params);
+
+    // The expected stake difficulty. Average the number of fresh stake
+    // since the last retarget to get the number of tickets per block,
+    // then use that to estimate the next stake difficulty.
+    const auto& bestHeight = chainActive.Tip()->nHeight;
+    const auto& lastAdjustment = (bestHeight / params.nStakeDiffWindowSize) * params.nStakeDiffWindowSize;
+    const auto& nextAdjustment = ((bestHeight / params.nStakeDiffWindowSize) + 1) * params.nStakeDiffWindowSize;
+    auto totalTickets = 0;
+    for (auto i = lastAdjustment; i <= bestHeight; i++) {
+        const auto& bh = chainActive.Tip()->GetAncestor(i)->GetBlockHeader();
+        totalTickets += bh.nFreshStake;
+    }
+    const auto& blocksSince = bestHeight - lastAdjustment + 1;
+    const auto& remaining = nextAdjustment - bestHeight - 1;
+    const auto& averagePerBlock = double(totalTickets) / blocksSince;
+    const auto& expectedTickets = floor(averagePerBlock * remaining);
+    const auto& expected = EstimateNextStakeDifficulty(chainActive.Tip(), expectedTickets, false, params);
 
     UniValue result(UniValue::VOBJ);
-    result.push_back(Pair("min", ValueFromAmount(0)));
-    result.push_back(Pair("max", ValueFromAmount(0)));
-    result.push_back(Pair("expected", ValueFromAmount(0)));
-
-    if (userTickets) {
-        result.push_back(Pair("user", ValueFromAmount(0)));
-    }
+    result.push_back(Pair("min", ValueFromAmount(min)));
+    result.push_back(Pair("max", ValueFromAmount(max)));
+    result.push_back(Pair("expected", ValueFromAmount(expected)));
+    result.push_back(Pair("user", ValueFromAmount(userEstimate)));
 
     return result;
 }
@@ -69,9 +138,15 @@ UniValue getstakedifficulty(const JSONRPCRequest& request)
             + HelpExampleCli("getstakedifficulty", "")
         );
 
+
+    LOCK(cs_main);
+    const auto& blockHeader = chainActive.Tip()->GetBlockHeader();
+    const auto& currentSdiff = blockHeader.nStakeDifficulty;
+    const auto& nextSdiff = CalculateNextRequiredStakeDifficulty(chainActive.Tip(), Params().GetConsensus());
+
     UniValue result(UniValue::VOBJ);
-    result.push_back(Pair("current", ValueFromAmount(0)));
-    result.push_back(Pair("next", ValueFromAmount(0)));
+    result.push_back(Pair("current", ValueFromAmount(currentSdiff)));
+    result.push_back(Pair("next", ValueFromAmount(nextSdiff)));
 
     return result;
 }
@@ -130,37 +205,68 @@ UniValue getstakeversioninfo(const JSONRPCRequest& request)
         numIntervals = static_cast<decltype(numIntervals)>(intNumIntervals);
     }
 
+    LOCK(cs_main);
+    auto pCurrentIndex = chainActive.Tip();
     UniValue result(UniValue::VOBJ);
-    result.push_back(Pair("currentheight", chainActive.Tip()->nHeight));
-    result.push_back(Pair("hash", chainActive.Tip()->GetBlockHash().ToString()));
+    result.push_back(Pair("currentheight", pCurrentIndex->nHeight));
+    result.push_back(Pair("hash", pCurrentIndex->GetBlockHash().ToString()));
 
-    uint8_t numVersions = 1;
+    const auto& stakeVersionInterval = Params().GetConsensus().nStakeVersionInterval;
+    const auto& stakeValidationHeight = Params().GetConsensus().nStakeValidationHeight;
+
+    auto startHeight = pCurrentIndex->nHeight;
+    auto endHeight = calcWantHeight(stakeValidationHeight, stakeVersionInterval, startHeight) + 1;
     UniValue resultIntervals(UniValue::VARR);
-    for (auto intervalIdx = 0u; intervalIdx < numIntervals; ++intervalIdx) {
-        UniValue resultInterval(UniValue::VOBJ);
-
-        resultInterval.push_back(Pair("startheight", chainActive.Tip()->nHeight));
-        resultInterval.push_back(Pair("endheight", chainActive.Tip()->nHeight));
-
-        UniValue posVersions(UniValue::VARR);
-        UniValue voteVersions(UniValue::VARR);
-        for (auto versionIdx = 0u; versionIdx < numVersions; ++versionIdx) {
-            UniValue posVersion(UniValue::VOBJ);
-            posVersion.push_back(Pair("version", 0));
-            posVersion.push_back(Pair("count", 0));
-
-            UniValue voteVersion(UniValue::VOBJ);
-            voteVersion.push_back(Pair("version", 0));
-            voteVersion.push_back(Pair("count", 0));
-
-            posVersions.push_back(posVersion);
-            voteVersions.push_back(voteVersion);
+    auto adjust = 1;
+    for (auto intervalIdx = 0u; intervalIdx < numIntervals; ++intervalIdx)
+    {
+        const auto& numBlocks = startHeight - endHeight;
+        if (numBlocks <= 0) {
+            // Just return what we got.
+            break;
         }
 
-        resultInterval.push_back(Pair("posversions", posVersions));
-        resultInterval.push_back(Pair("voteversions", voteVersions));
+        const auto& sv = GetStakeVersions(pCurrentIndex, numBlocks+adjust);
+        auto posVersions = std::map<int,int>{};
+        auto voteVersions = std::map<int,int>{};
+        for (const auto& v : sv)
+        {
+            posVersions[int(v.stakeVersion)]++;
+            for (const auto& vote : v.votes)
+            {
+                voteVersions[int(vote.Version)]++;
+            }
+        }
 
-        resultIntervals.push_back(resultInterval);
+        UniValue versionInterval(UniValue::VOBJ);
+
+        versionInterval.push_back(Pair("startheight", startHeight));
+        versionInterval.push_back(Pair("endheight", endHeight));
+
+        auto ConvertVersionMap = [](const std::map<int, int>& versionsMap) {
+            UniValue versions(UniValue::VARR);
+            for (const auto& kv : versionsMap) {
+                UniValue version(UniValue::VOBJ);
+                version.push_back(Pair("version", kv.first));
+                version.push_back(Pair("count", kv.second));
+                versions.push_back(version);
+            }
+            return versions;
+        };
+
+
+        versionInterval.push_back(Pair("posversions", ConvertVersionMap(posVersions)));
+        versionInterval.push_back(Pair("voteversions", ConvertVersionMap(voteVersions)));
+
+        resultIntervals.push_back(versionInterval);
+
+        // Adjust interval.
+        endHeight -= stakeVersionInterval;
+        startHeight = endHeight + stakeVersionInterval;
+        adjust = 0;
+
+        // Get prior block index.
+        pCurrentIndex = pCurrentIndex->pprev;
     }
 
     result.push_back(Pair("intervals", resultIntervals));
@@ -206,29 +312,37 @@ UniValue getstakeversions(const JSONRPCRequest& request)
     if (!IsHex(hashStr)) {
         throw JSONRPCError(RPCErrorCode::INVALID_PARAMETER, "Invalid hash format provided");
     }
+    const auto hash = uint256S(hashStr);
 
     auto intCountBlocks = request.params[1].get_int();
     if (intCountBlocks <= 0) {
         throw JSONRPCError(RPCErrorCode::INVALID_PARAMETER, "Invalid count of blocks, must be greater than zero");
     }
-    auto countBlocks = static_cast<uint32_t>(intCountBlocks);
 
-    size_t numVotes = 1;
+    LOCK(cs_main);
+
+    if (mapBlockIndex.count(hash) == 0)
+        throw JSONRPCError(RPCErrorCode::INVALID_ADDRESS_OR_KEY, "Block not found");
+
+    const auto * const pblockindex = mapBlockIndex[hash];
+
+    const auto& sv = GetStakeVersions(pblockindex, intCountBlocks);
+
     UniValue result(UniValue::VARR);
 
-    for (auto countIdx = 0u; countIdx < countBlocks; ++countIdx) {
+    for (const auto& v : sv) {
         UniValue stakeVersion(UniValue::VOBJ);
 
-        stakeVersion.push_back(Pair("hash", chainActive.Tip()->GetBlockHeader().GetHash().ToString()));
-        stakeVersion.push_back(Pair("height", chainActive.Tip()->nHeight));
-        stakeVersion.push_back(Pair("blockversion", 0));
-        stakeVersion.push_back(Pair("stakeversion", 0));
+        stakeVersion.push_back(Pair("hash", v.hash.ToString()));
+        stakeVersion.push_back(Pair("height", v.height));
+        stakeVersion.push_back(Pair("blockversion", v.blockVersion));
+        stakeVersion.push_back(Pair("stakeversion", static_cast<int>(v.stakeVersion)));
 
         UniValue votes(UniValue::VARR);
-        for (auto voteIdx = 0u; voteIdx < numVotes; ++voteIdx) {
+        for (const auto& voteIt : v.votes) {
             UniValue vote(UniValue::VOBJ);
-            vote.push_back(Pair("version", 0));
-            vote.push_back(Pair("bits", 0));
+            vote.push_back(Pair("version", static_cast<int>(voteIt.Version)));
+            vote.push_back(Pair("bits", voteIt.Bits));
 
             votes.push_back(vote);
         }

--- a/src/stake/stakeversion.cpp
+++ b/src/stake/stakeversion.cpp
@@ -1,0 +1,274 @@
+#include "stakeversion.h"
+
+#include "primitives/block.h"
+
+#include <map>
+
+enum {
+    StakeIntervalError_BadNode = -1,
+    StakeIntervalError_MajorityNotFound = -2
+};
+
+struct StakeMajorityKey {
+    uint32_t version;
+    uint256 hash;
+
+    bool operator<(const StakeMajorityKey& key) const
+    {
+       return version < key.version && hash < key.hash;
+    }
+};
+
+// cached state of stake versions related to intervals;
+// to protect access, calls of functions below must be guarded by locks.
+std::map<StakeMajorityKey,bool> isStakeMajorityVersionCache;
+std::map<uint256,uint32_t> priorStakeVersionCache;
+std::map<uint256,uint32_t> calcVoterVersionIntervalCache;
+std::map<uint256,uint32_t> stakeVersionCache;
+
+// stakeMajorityCacheVersionKey creates a map key that is comprised of a stake
+// version and a hash.  This is used for caches that require a version in
+// addition to a simple hash.
+StakeMajorityKey stakeMajorityCacheVersionKey(uint32_t version, const uint256* phash)
+{
+    StakeMajorityKey key = { version, *phash };
+    return key;
+}
+
+// calcWantHeight calculates the height of the final block of the previous interval
+// given a stake validation height, stake validation interval, and block height.
+int64_t calcWantHeight(int64_t stakeValidationHeight, int64_t interval, int64_t height)
+{
+    // The adjusted height accounts for the fact the starting validation height does not necessarily start on an interval
+    // and thus the intervals might not be zero-based.
+    const auto& intervalOffset = stakeValidationHeight % interval;
+    const auto& adjustedHeight = height - intervalOffset - 1;
+    return (adjustedHeight - ((adjustedHeight + 1) % interval)) + intervalOffset;
+}
+
+// findStakeVersionPriorNode walks the chain backwards from prevNode until it
+// reaches the final block of the previous stake version interval and returns
+// that node.  The returned node will be nil when the provided prevNode is too
+// low such that there is no previous stake version interval due to falling
+// prior to the stake validation interval.
+//
+// This function MUST be called with the chain state lock held (for writes).
+const CBlockIndex* findStakeVersionPriorNode(const CBlockIndex *pprevIndex, const Consensus::Params& params)
+{
+    // Check to see if the blockchain is high enough to begin accounting stake versions.
+    uint32_t nextHeight = pprevIndex->nHeight + 1;
+    if (nextHeight < params.nStakeValidationHeight + params.nStakeVersionInterval)
+        return nullptr;
+
+    uint32_t wantHeight = calcWantHeight(params.nStakeValidationHeight, params.nStakeVersionInterval, nextHeight);
+    return pprevIndex->GetAncestor(wantHeight);
+}
+
+// isStakeMajorityVersion determines if minVer requirement is met based on
+// prevNode.  The function always uses the stake versions of the prior window.
+// For example, if StakeVersionInterval = 11 and StakeValidationHeight = 13 the
+// windows start at 13 + (11 * 2) 25 and are as follows: 24-34, 35-45, 46-56 ...
+// If height comes in at 35 we use the 24-34 window, up to height 45.
+// If height comes in at 46 we use the 35-45 window, up to height 56 etc.
+//
+// This function MUST be called with the chain state lock held (for writes).
+bool isStakeMajorityVersion(uint32_t minVer, const CBlockIndex* pprevIndex, const Consensus::Params& params)
+{
+    // Walk blockchain backwards to calculate version.
+    const CBlockIndex *pIndex = findStakeVersionPriorNode(pprevIndex, params);
+    if (pIndex == nullptr)
+        return 0 >= minVer;
+
+    // Generate map key and look up cached result.
+    auto key = stakeMajorityCacheVersionKey(minVer, pIndex->phashBlock);
+    if (isStakeMajorityVersionCache.find(key) != isStakeMajorityVersionCache.end())
+        return isStakeMajorityVersionCache[key];
+
+    // Tally how many of the block headers in the previous stake version validation interval
+    // have their stake version set to at least the requested minimum version.
+    int versionCount = 0;
+    const CBlockIndex *pIterIndex = pIndex;
+    for (int i = 0; i < params.nStakeVersionInterval && pIterIndex != nullptr; i++) {
+        if (pIterIndex->nStakeVersion >= minVer)
+            versionCount++;
+
+        pIterIndex = pIterIndex->pprev;
+    }
+
+    // Determine the required amount of votes to reach supermajority.
+    auto numRequired = params.nStakeVersionInterval * params.nStakeMajorityMultiplier / params.nStakeMajorityDivisor;
+
+    // Cache result.
+    bool result = versionCount >= numRequired;
+    isStakeMajorityVersionCache[key] = result;
+
+    return result;
+}
+
+// calcPriorStakeVersion calculates the header stake version of the prior
+// interval. The function walks the chain backwards by one interval and then
+// it performs a standard majority calculation.
+//
+// This function MUST be called with the chain state lock held (for writes).
+int calcPriorStakeVersion(const CBlockIndex *pprevIndex, const Consensus::Params& params)
+{
+    // Walk blockchain backwards to calculate version.
+    const CBlockIndex* pIndex = findStakeVersionPriorNode(pprevIndex, params);
+    if (pIndex == nullptr)
+        return -1;
+
+    // Check cache.
+    if (priorStakeVersionCache.find(pIndex->GetBlockHash()) != priorStakeVersionCache.end())
+        return priorStakeVersionCache[pIndex->GetBlockHash()];
+
+    // Tally how many of each stake version the block headers in the previous stake
+    // version validation interval have.
+    std::map<uint32_t,uint32_t> versions;
+    const CBlockIndex *pIterNode = pIndex;
+    for (int i = 0; i < params.nStakeVersionInterval && pIterNode != nullptr; i++) {
+        if (versions.find(pIterNode->nStakeVersion) == versions.end())
+            versions[pIterNode->nStakeVersion] = 1;
+        else
+            versions[pIterNode->nStakeVersion]++;
+
+        pIterNode = pIterNode->pprev;
+    }
+
+    // Determine the required amount of votes to reach supermajority.
+    auto numRequired = params.nStakeVersionInterval * params.nStakeMajorityMultiplier / params.nStakeMajorityDivisor;
+
+    for (auto elem : versions) {
+        auto count = elem.second;
+        if (count >= numRequired) {
+            auto version = elem.first;
+            priorStakeVersionCache[pIndex->GetBlockHash()] = version;
+            return version;
+        }
+    }
+
+    return StakeIntervalError_MajorityNotFound;
+}
+
+// calcVoterVersionInterval tallies all voter versions in an interval and
+// returns a version that has reached 75% majority.  This function MUST be
+// called with a node that is the final node in a valid stake version interval
+// and greater than or equal to the stake validation height or it will result in
+// an assertion error.
+//
+// This function is really meant to be called internally only from this file.
+//
+// This function MUST be called with the chain state lock held (for writes).
+int calcVoterVersionInterval(const CBlockIndex *pprevIndex, const Consensus::Params& params)
+{
+    // Ensure the provided node is the final node in a valid stake version
+    // interval and is greater than or equal to the stake validation height
+    // since the logic below relies on these assumptions.
+    int expectedHeight = calcWantHeight(params.nStakeValidationHeight, params.nStakeVersionInterval, pprevIndex->nHeight + 1);
+    if (pprevIndex->nHeight != expectedHeight || expectedHeight < params.nStakeValidationHeight) {
+        assert(!"calcVoterVersionInterval must be called with a node that is the final node in a stake version interval");
+        return StakeIntervalError_BadNode;
+    }
+
+    // See if we have cached results.
+    if (calcVoterVersionIntervalCache.find(pprevIndex->GetBlockHash()) != calcVoterVersionIntervalCache.end())
+        return (int)calcVoterVersionIntervalCache[pprevIndex->GetBlockHash()];
+
+    // Tally both the total number of votes in the previous stake version validation
+    // interval and how many of each version those votes have.
+    std::map<uint32_t, uint32_t> versions; // version -> count
+    uint32_t totalVotesFound = 0;
+    const CBlockIndex *pIterIndex = pprevIndex;
+    for (int i = 0; i < params.nStakeVersionInterval && pIterIndex != nullptr; i++) {
+        totalVotesFound += pIterIndex->votes.size();
+        for (auto &v : pIterIndex->votes) {
+            if (versions.find(v.Version) == versions.end())
+                versions[v.Version] = 1;
+            else
+                versions[v.Version]++;
+        }
+        pIterIndex = pIterIndex->pprev;
+    }
+
+    // Determine the required amount of votes to reach supermajority.
+    auto numRequired = totalVotesFound * params.nStakeMajorityMultiplier / params.nStakeMajorityDivisor;
+
+    for (auto elem : versions) {
+        auto count = elem.second;
+        if (count >= numRequired) {
+            auto version = elem.first;
+            calcVoterVersionIntervalCache[pprevIndex->GetBlockHash()] = version;
+            return version;
+        }
+    }
+
+    return StakeIntervalError_MajorityNotFound;
+}
+
+// calcVoterVersion calculates the last prior valid majority stake version.  If
+// the current interval does not have a majority stake version it'll go back to
+// the prior interval.  It'll keep going back up to the minimum height at which
+// point we know the version was 0.
+//
+// This function MUST be called with the chain state lock held (for writes).
+uint32_t calcVoterVersion(const CBlockIndex* pprevIndex, CBlockIndex **pIntervalNodePtr, const Consensus::Params& params)
+{
+    // Walk blockchain backwards to find interval.
+    const CBlockIndex *pIndex = findStakeVersionPriorNode(pprevIndex, params);
+
+    // Iterate over versions until a majority is found.
+    // Don't try to count votes before the stake validation height since there could not possibly have been any.
+    while (pIndex != nullptr && pIndex->nHeight >= params.nStakeValidationHeight) {
+        int version = calcVoterVersionInterval(pIndex, params);
+        if (version >= 0) {
+            *pIntervalNodePtr = (CBlockIndex*)pIndex;
+            return version;
+        }
+        if (version != StakeIntervalError_MajorityNotFound)
+            break;
+
+        pIndex = pIndex->GetRelativeAncestor(params.nStakeVersionInterval);
+    }
+
+    // No majority version found.
+    return 0;
+}
+
+// calcStakeVersion calculates the header stake version based on voter versions.
+// If there is a majority of voter versions it uses the header stake version to
+// prevent reverting to a prior version.
+//
+// This function MUST be called with the chain state lock held (for writes).
+uint32_t calcStakeVersion(const CBlockIndex *pprevIndex, const Consensus::Params& params)
+{
+    CBlockIndex *pIndex = nullptr;
+    uint32_t version = calcVoterVersion(pprevIndex, &pIndex, params);
+    if (version == 0 || pIndex == nullptr)
+        return 0;
+
+    // Check cache.
+    if (stakeVersionCache.find(pIndex->GetBlockHash()) != stakeVersionCache.end())
+        return stakeVersionCache[pIndex->GetBlockHash()];
+
+    // Walk chain backwards to start of node interval (start of current
+    // period) Note that calcWantHeight returns the LAST height of the
+    // prior interval; hence the + 1.
+    uint32_t startIntervalHeight = calcWantHeight(params.nStakeValidationHeight, params.nStakeVersionInterval, pIndex->nHeight) + 1;
+    CBlockIndex* pStartNode = pIndex->GetAncestor(startIntervalHeight);
+    if (pStartNode == nullptr) {
+        // Note that should this not be possible to hit because a
+        // majority voter version was obtained above, which means there
+        // is at least an interval of nodes.  However, be paranoid.
+        stakeVersionCache[pIndex->GetBlockHash()] = 0;
+    }
+
+    // Don't allow the stake version to go backwards once it has been locked in by a previous majority,
+    // even if the majority of votes are now a lower version.
+    if (isStakeMajorityVersion(version, pIndex, params)) {
+        int priorVersion = calcPriorStakeVersion(pIndex, params);
+        if (priorVersion >= 0 && (uint32_t)priorVersion > version)
+            version = (uint32_t) priorVersion;
+    }
+
+    stakeVersionCache[pIndex->GetBlockHash()] = version;
+    return version;
+}

--- a/src/stake/stakeversion.h
+++ b/src/stake/stakeversion.h
@@ -1,0 +1,12 @@
+#ifndef STAKEVERSION_H
+#define STAKEVERSION_H
+
+#include "consensus/params.h"
+#include "chain.h"
+
+#include <stdint.h>
+
+uint32_t calcStakeVersion(const CBlockIndex *pprevIndex, const Consensus::Params& params);
+int64_t calcWantHeight(int64_t stakeValidationHeight, int64_t interval, int64_t height);
+
+#endif // STAKEVERSION_H

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -142,7 +142,7 @@ CMutableTransaction CreateDummyBuyTicket(const CAmount& contribution)
     auto rewardKey = CKey();
     rewardKey.MakeNewKey(false);
     auto rewardAddr = rewardKey.GetPubKey().GetID();
-    TicketContribData ticketContribData = { 1, rewardAddr, contribution };
+    const auto& ticketContribData = TicketContribData{ 1, rewardAddr, contribution };
     CScript contributorInfoScript = GetScriptForTicketContrib(ticketContribData);
     mtx.vout.push_back(CTxOut(0, contributorInfoScript));
 

--- a/src/test/stake_difficulty_tests.cpp
+++ b/src/test/stake_difficulty_tests.cpp
@@ -22,29 +22,117 @@ struct TicketInfo
     int64_t  stakeDiff;
 };
 
-struct SDiffTest
+struct CalculateSDiffTest
 {
     std::string name;
     std::vector<TicketInfo> vTicketInfo;
     int64_t expectedDiff;
 };
 
+struct EstimateSDiffTest
+{
+    std::string name;
+    std::vector<TicketInfo> vTicketInfo;
+    int64_t  newTickets;
+    bool useMaxTickets;
+    int64_t expectedDiff;
+};
+
+static void loopTicketInfo(CChain& fakeChain, const std::vector<TicketInfo>& vTicketInfo, const Consensus::Params& params)
+{
+    // const auto& stakeEnabledHeight = params.nStakeEnabledHeight;
+    const auto& stakeValidationHeight = params.nStakeValidationHeight;
+    const auto& ticketMaturity = params.nTicketMaturity;
+    // const auto& ticketExpiry = params.nTicketExpiry;
+    const auto& ticketsPerBlock = params.nTicketsPerBlock;
+    // const auto& maxFreshTicketsPerBlock = params.nMaxFreshStakePerBlock;
+
+    // immatureTickets track which height the purchased tickets will
+    // mature and thus be eligible for admission to the live ticket
+    // pool.
+    auto immatureTickets = std::map<uint32_t,uint8_t>{};
+    auto poolSize  = uint32_t{};
+
+    for (const auto& ticketInfo: vTicketInfo) 
+    {
+        // Ensure the test data isn't faking ticket purchases at
+        // an incorrect difficulty.
+        auto tip = fakeChain.Tip();
+        const auto& req_diff = CalculateNextRequiredStakeDifficulty(tip, params);
+        BOOST_CHECK_EQUAL(req_diff, ticketInfo.stakeDiff);
+
+        for (uint32_t i = 0; i < ticketInfo.numNodes; ++i) 
+        {
+            // Make up a header.
+            const auto& nextHeight = tip->nHeight + 1;
+            auto bheader = CBlockHeader{};
+            bheader.nVersion = tip->nVersion;
+            bheader.nStakeDifficulty = ticketInfo.stakeDiff;
+            bheader.nFreshStake = ticketInfo.newTickets,
+            bheader.nTicketPoolSize = poolSize;
+
+            auto block = new CBlockIndex(bheader);
+            block->nHeight = nextHeight;
+            block->pprev = tip;
+            tip = block;
+
+            // Update the pool size for the next header.
+            // Notice how tickets that mature for this block
+            // do not show up in the pool size until the
+            // next block.  This is correct behavior.
+            poolSize += immatureTickets[nextHeight];
+            immatureTickets[nextHeight] = 0;
+            if (nextHeight >= stakeValidationHeight) {
+                poolSize -= ticketsPerBlock;
+            }
+
+            // Track maturity height for new ticket
+            // purchases.
+            const auto& maturityHeight = nextHeight + ticketMaturity;
+            immatureTickets[maturityHeight] = ticketInfo.newTickets;
+
+            // Update the chain to use the new fake node as
+            // the new best node.
+            fakeChain.SetTip(tip);
+        }
+    }
+
+}
+
+static void CalculateSDiffLoop(const std::vector<CalculateSDiffTest>& tests, const Consensus::Params& params)
+{
+    for (const auto& test : tests)
+    {
+        auto fakeChain = chainActive;
+        loopTicketInfo(fakeChain, test.vTicketInfo, params);
+        // Ensure the calculated difficulty matches the expected value.
+        const auto& stake_diff = CalculateNextRequiredStakeDifficulty(fakeChain.Tip(), params);
+        BOOST_CHECK_EQUAL(stake_diff, test.expectedDiff);
+    }
+}
+
+static void EstimateSDiffLoop(const std::vector<EstimateSDiffTest>& tests, const Consensus::Params& params)
+{
+    for (const auto& test : tests)
+    {
+        auto fakeChain = chainActive;
+        loopTicketInfo(fakeChain, test.vTicketInfo,params);
+        // Ensure the calculated difficulty matches the expected value.
+        const auto& gotDiff = EstimateNextStakeDifficulty(fakeChain.Tip(), test.newTickets, test.useMaxTickets, params);
+        BOOST_CHECK_EQUAL(gotDiff, test.expectedDiff);
+    }
+}
+
 BOOST_FIXTURE_TEST_SUITE(stake_difficulty_tests, TestingSetup)
 
 // get_next_required_stake_diff ensure the stake diff calculation function works as expected.
-BOOST_AUTO_TEST_CASE(get_next_required_stake_diff)
+BOOST_AUTO_TEST_CASE(get_next_required_stake_diff_MAIN)
 {
     // const auto& my_tip = chainActive.Tip();
-    const CChainParams& chainparams = Params();
-    // const auto& stakeEnabledHeight = chainparams.GetConsensus().nStakeEnabledHeight;
-    const auto& stakeValidationHeight = chainparams.GetConsensus().nStakeValidationHeight;
-    const auto& minStakeDiff = chainparams.GetConsensus().nMinimumStakeDiff /*+ 2e4*/;
-    const auto& ticketMaturity = chainparams.GetConsensus().nTicketMaturity;
-    // const auto& ticketExpiry = chainparams.GetConsensus().nTicketExpiry;
-    const auto& ticketsPerBlock = chainparams.GetConsensus().nTicketsPerBlock;
-    // const auto& maxFreshTicketsPerBlock = chainparams.GetConsensus().nMaxFreshStakePerBlock;
+    const auto& params = Params().GetConsensus();
+    const auto& minStakeDiff = params.nMinimumStakeDiff;
 
-    const auto& tests = std::vector<SDiffTest>{
+    const auto& tests = std::vector<CalculateSDiffTest>{
         {
             // Next retarget is at 144.  Prior to coinbase maturity,
             // so will always be the minimum.
@@ -249,62 +337,470 @@ BOOST_AUTO_TEST_CASE(get_next_required_stake_diff)
         // },
     };
 
-    for (const auto& test : tests) {
-        auto fakeChain = chainActive;
-
-        auto poolSize = uint32_t{0};
-
-        // immatureTickets tracks which height the purchased tickets
-        // will mature and thus be eligible for admission to the live
-        // ticket pool.
-        auto immatureTickets = std::map<uint32_t,uint8_t>{};
-
-        for (const auto& ticketInfo: test.vTicketInfo) 
-        {
-            auto tip = fakeChain.Tip();
-            const auto& stake_diff = CalculateNextRequiredStakeDifficulty(tip, chainparams.GetConsensus());
-            BOOST_CHECK_EQUAL(stake_diff, ticketInfo.stakeDiff);
-
-            for (uint32_t i = 0; i < ticketInfo.numNodes; ++i) 
-            {
-                const auto& nextHeight = tip->nHeight + 1;
-                auto bheader = CBlockHeader{};
-                bheader.nVersion = tip->nVersion;
-                bheader.nStakeDifficulty = ticketInfo.stakeDiff;
-                bheader.nFreshStake = ticketInfo.newTickets,
-                bheader.nTicketPoolSize = poolSize;
-
-                auto block = new CBlockIndex(bheader);
-                block->nHeight = nextHeight;
-                block->pprev = tip;
-                tip = block;
-
-                // Update the pool size for the next header.
-                // Notice how tickets that mature for this block
-                // do not show up in the pool size until the
-                // next block.  This is correct behavior.
-                poolSize += immatureTickets[nextHeight];
-                immatureTickets[nextHeight] = 0;
-                if (nextHeight >= stakeValidationHeight) {
-                    poolSize -= ticketsPerBlock;
-                }
-
-                // Track maturity height for new ticket
-                // purchases.
-                const auto& maturityHeight = nextHeight + ticketMaturity;
-                immatureTickets[maturityHeight] = ticketInfo.newTickets;
-
-                // Update the chain to use the new fake node as
-                // the new best node.
-                fakeChain.SetTip(tip);
-            }
-
-        }
-
-        const auto& stake_diff = CalculateNextRequiredStakeDifficulty(fakeChain.Tip(), chainparams.GetConsensus());
-        BOOST_CHECK_EQUAL(stake_diff, test.expectedDiff);
-    }
+    CalculateSDiffLoop(tests, params);
 }
 
+// estimate_next_stake_diff ensures the function that estimates the stake
+// diff calculation for the algorithm defined by DCP0001 works as expected.
+BOOST_AUTO_TEST_CASE(estimate_next_stake_diff_MAIN)
+{
+    const auto& params = Params().GetConsensus();
+    const auto& minStakeDiffMainNet = params.nMinimumStakeDiff;
+
+    const auto& tests = std::vector<EstimateSDiffTest>{
+        {
+            // Regardless of claiming tickets will be purchased, the
+            // resulting stake difficulty should be the minimum
+            // because the first retarget is before the start
+            // height.
+            "genesis block",
+            {{0, 0, minStakeDiffMainNet}},
+            2860,
+            false,
+            minStakeDiffMainNet,
+        },
+        {
+            // Next retarget is 144.  Resulting stake difficulty
+            // should be the minimum regardless of claimed ticket
+            // purchases because the previous pool size is still 0.
+            "during retarget, but before coinbase",
+            {{140, 0, minStakeDiffMainNet}},
+            20 * 3, // blocks 141, 142, and 143.
+            true,
+            minStakeDiffMainNet,
+        },
+        {
+            // Next retarget is at 288.  Regardless of claiming
+            // tickets will be purchased, the resulting stake
+            // difficulty should be the min because the previous
+            // pool size is still 0.
+            "at coinbase maturity",
+            {{256, 0, minStakeDiffMainNet}},
+            0,
+            true,
+            minStakeDiffMainNet,
+        },
+        {
+            // Next retarget is at 288.  Regardless of actually
+            // purchasing tickets and claiming more tickets will be
+            // purchased, the resulting stake difficulty should be
+            // the min because the previous pool size is still 0.
+            "2nd retarget interval - 2, 100% demand",
+            {
+                {256, 0, minStakeDiffMainNet}, // 256
+                {30, 20, minStakeDiffMainNet}, // 286
+            },
+            0,
+            true,
+            minStakeDiffMainNet,
+        },
+        {
+            // Next retarget is at 288.  Still expect minimum stake
+            // difficulty since the raw result would be lower.
+            "2nd retarget interval - 1, 100% demand",
+            {
+                {256, 0, minStakeDiffMainNet}, // 256
+                {31, 20, minStakeDiffMainNet}, // 287
+            },
+            0,
+            true,
+            minStakeDiffMainNet,
+        },
+        {
+            // Next retarget is at 432.
+            "3rd retarget interval, 100% demand, 1st block",
+            {
+                {256, 0, minStakeDiffMainNet}, // 256
+                {32, 20, minStakeDiffMainNet}, // 288
+            },
+            0,
+            true,
+            minStakeDiffMainNet,
+        },
+        {
+            // Next retarget is at 2304.
+            "16th retarget interval, 100% demand, 1st block",
+            {
+                {256, 0, minStakeDiffMainNet},   // 256
+                {1904, 20, minStakeDiffMainNet}, // 2160
+            },
+            0,
+            true,
+            208418769,
+        },
+        {
+            // Next retarget is at 2304.
+            "16th retarget interval, 100% demand, 2nd block",
+            {
+                {256, 0, minStakeDiffMainNet},   // 256
+                {1905, 20, minStakeDiffMainNet}, // 2161
+            },
+            0,
+            true,
+            208418769,
+        },
+        {
+            // Next retarget is at 2304.
+            "16th retarget interval, 100% demand, final block",
+            {
+                {256, 0, minStakeDiffMainNet},   // 256
+                {2047, 20, minStakeDiffMainNet}, // 2303
+            },
+            0,
+            true,
+            208418769,
+        },
+        {
+            // Next retarget is at 3456.
+            "24th retarget interval, varying demand, 5th block",
+            {
+                {256, 0, minStakeDiffMainNet},  // 256
+                {31, 20, minStakeDiffMainNet},  // 287
+                {144, 10, minStakeDiffMainNet}, // 431
+                {144, 20, minStakeDiffMainNet}, // 575
+                {144, 10, minStakeDiffMainNet}, // 719
+                {144, 20, minStakeDiffMainNet}, // 863
+                {144, 10, minStakeDiffMainNet}, // 1007
+                {144, 20, minStakeDiffMainNet}, // 1151
+                {144, 10, minStakeDiffMainNet}, // 1295
+                {144, 20, minStakeDiffMainNet}, // 1439
+                {144, 10, minStakeDiffMainNet}, // 1583
+                {144, 20, minStakeDiffMainNet}, // 1727
+                {144, 10, minStakeDiffMainNet}, // 1871
+                {144, 20, minStakeDiffMainNet}, // 2015
+                {144, 10, minStakeDiffMainNet}, // 2159
+                {144, 20, minStakeDiffMainNet}, // 2303
+                {144, 10, minStakeDiffMainNet}, // 2447
+                {144, 20, minStakeDiffMainNet}, // 2591
+                {144, 10, minStakeDiffMainNet}, // 2735
+                {144, 20, minStakeDiffMainNet}, // 2879
+                {144, 9, 201743368},            // 3023
+                {144, 20, 201093236},           // 3167
+                {144, 8, 222625877},            // 3311
+                {5, 20, 242331291},             // 3316
+            },
+            0,
+            true,
+            291317641,
+        },
+        // {
+        //     // Next retarget is at 4176.  Post stake validation
+        //     // height.
+        //     "29th retarget interval, 100% demand, 10th block",
+        //     {
+        //         {256, 0, minStakeDiffMainNet},   // 256
+        //         {2047, 20, minStakeDiffMainNet}, // 2303
+        //         {144, 20, 208418769},            // 2447
+        //         {144, 20, 231326567},            // 2591
+        //         {144, 20, 272451490},            // 2735
+        //         {144, 20, 339388424},            // 2879
+        //         {144, 20, 445827839},            // 3023
+        //         {144, 20, 615949254},            // 3167
+        //         {144, 20, 892862990},            // 3311
+        //         {144, 20, 1354989669},           // 3455
+        //         {144, 20, 2148473276},           // 3599
+        //         {144, 20, 3552797658},           // 3743
+        //         {144, 20, 6116808441},           // 3887
+        //         {144, 20, 10947547379},          // 4031
+        //         {10, 20, 20338554623},           // 4041
+        //     },
+        //     0,
+        //     true,
+        //     22097687698,
+        // },
+        {
+            // Next retarget is at 4176.  Post stake validation
+            // height.
+            "29th retarget interval, 50% demand, 23rd block",
+            {
+                {256, 0, minStakeDiffMainNet},   // 256
+                {3775, 10, minStakeDiffMainNet}, // 4031
+                {23, 10, minStakeDiffMainNet},   // 4054
+            },
+            1210, // 121 * 10
+            false,
+            minStakeDiffMainNet,
+        },
+        // {
+        //     // Next retarget is at 4464.  Post stake validation
+        //     // height.
+        //     "31st retarget interval, waning demand, 117th block",
+        //     {
+        //         {256, 0, minStakeDiffMainNet},   // 256
+        //         {2047, 20, minStakeDiffMainNet}, // 2303
+        //         {144, 20, 208418769},            // 2447
+        //         {144, 20, 231326567},            // 2591
+        //         {144, 20, 272451490},            // 2735
+        //         {144, 20, 339388424},            // 2879
+        //         {144, 20, 445827839},            // 3023
+        //         {144, 20, 615949254},            // 3167
+        //         {144, 20, 892862990},            // 3311
+        //         {144, 20, 1354989669},           // 3455
+        //         {144, 20, 2148473276},           // 3599
+        //         {144, 20, 3552797658},           // 3743
+        //         {144, 13, 6116808441},           // 3887
+        //         {144, 0, 10645659768},           // 4031
+        //         {144, 0, 18046712136},           // 4175
+        //         {144, 0, 22097687698},           // 4319
+        //         {117, 0, 22152524112},           // 4436
+        //     },
+        //     0,
+        //     false,
+        //     22207360526,
+        // },
+    };
+
+    EstimateSDiffLoop(tests, params);
+}
+
+struct TestingSetup_TEST : public TestingSetup
+{
+    explicit TestingSetup_TEST(const std::string& chainName = CBaseChainParams::TESTNET)
+    : TestingSetup(chainName)
+    {
+        ;
+    };
+
+    ~TestingSetup_TEST(){};
+};
+
+BOOST_FIXTURE_TEST_CASE(estimate_next_stake_diff_TEST, TestingSetup_TEST)
+{
+    // --------------------------
+    // TestNet params start here.
+    // --------------------------
+    const auto& testNetParams = Params().GetConsensus();
+    const auto& minStakeDiffTestNet = testNetParams.nMinimumStakeDiff;
+    const auto& tests = std::vector<EstimateSDiffTest>{
+        // TODO this returns the nStakeDiff of the genesis block which in our case is 
+        //      initialized with zero
+        // {
+        //     // Regardless of claiming tickets will be purchased, the
+        //     // resulting stake difficulty should be the minimum
+        //     // because the first retarget is before the start
+        //     // height.
+        //     "genesis block",
+        //     {{0, 0, minStakeDiffTestNet}},
+        //     2860,
+        //     false,
+        //     minStakeDiffTestNet,
+        // },
+        {
+            // Next retarget is at 144.  Regardless of claiming
+            // tickets will be purchased, the resulting stake
+            // difficulty should be the min because the previous
+            // pool size is still 0.
+            "at coinbase maturity",
+            {{16, 0, minStakeDiffTestNet}},
+            0,
+            true,
+            minStakeDiffTestNet,
+        },
+        {
+            // Next retarget is at 144.  Regardless of actually
+            // purchasing tickets and claiming more tickets will be
+            // purchased, the resulting stake difficulty should be
+            // the min because the previous pool size is still 0.
+            "1st retarget interval - 2, 100% demand",
+            {
+                {16, 0, minStakeDiffTestNet},   // 16
+                {126, 20, minStakeDiffTestNet}, // 142
+            },
+            0,
+            true,
+            minStakeDiffTestNet,
+        },
+        {
+            // Next retarget is at 288.  Still expect minimum stake
+            // difficulty since the raw result would be lower.
+            "2nd retarget interval - 1, 30% demand",
+            {
+                {16, 0, minStakeDiffTestNet},  // 16
+                {271, 6, minStakeDiffTestNet}, // 287
+            },
+            0,
+            true,
+            minStakeDiffTestNet,
+        },
+        {
+            // Next retarget is at 288.  Still expect minimum stake
+            // difficulty since the raw result would be lower.
+            //
+            // Since the ticket maturity is smaller than the
+            // retarget interval, this case ensures some of the
+            // nodes being estimated will mature during the
+            // interval.
+            "2nd retarget interval - 23, 30% demand",
+            {
+                {16, 0, minStakeDiffTestNet},  // 16
+                {249, 6, minStakeDiffTestNet}, // 265
+            },
+            132, // 22 * 6
+            false,
+            minStakeDiffTestNet,
+        },
+        {
+            // Next retarget is at 288.  Still expect minimum stake
+            // difficulty since the raw result would be lower.
+            //
+            // None of the nodes being estimated will mature during the
+            // interval.
+            "2nd retarget interval - 11, 30% demand",
+            {
+                {16, 0, minStakeDiffTestNet},  // 16
+                {261, 6, minStakeDiffTestNet}, // 277
+            },
+            60, // 10 * 6
+            false,
+            minStakeDiffTestNet,
+        },
+        {
+            // Next retarget is at 432.
+            "3rd retarget interval, 100% demand, 1st block",
+            {
+                {16, 0, minStakeDiffTestNet},   // 16
+                {256, 20, minStakeDiffTestNet}, // 288
+            },
+            0,
+            true,
+            44505494,
+        },
+        {
+            // Next retarget is at 432.
+            //
+            // None of the nodes being estimated will mature during the
+            // interval.
+            "3rd retarget interval - 11, 100% demand",
+            {
+                {16, 0, minStakeDiffTestNet},   // 16
+                {271, 20, minStakeDiffTestNet}, // 287
+                {134, 20, 44505494},            // 421
+            },
+            0,
+            true,
+            108661875,
+        },
+        {
+            // Next retarget is at 576.
+            "4th retarget interval, 100% demand, 1st block",
+            {
+                {16, 0, minStakeDiffTestNet},   // 16
+                {271, 20, minStakeDiffTestNet}, // 287
+                {144, 20, 44505494},            // 431
+                {1, 20, 108661875},             // 432
+            },
+            0,
+            true,
+            314319918,
+        },
+        {
+            // Next retarget is at 576.
+            "4th retarget interval, 100% demand, 2nd block",
+            {
+                {16, 0, minStakeDiffTestNet},   // 16
+                {271, 20, minStakeDiffTestNet}, // 287
+                {144, 20, 44505494},            // 431
+                {2, 20, 108661875},             // 433
+            },
+            0,
+            true,
+            314319918,
+        },
+        {
+            // Next retarget is at 576.
+            "4th retarget interval, 100% demand, final block",
+            {
+                {16, 0, minStakeDiffTestNet},   // 16
+                {271, 20, minStakeDiffTestNet}, // 287
+                {144, 20, 44505494},            // 431
+                {144, 20, 108661875},           // 575
+            },
+            0,
+            true,
+            314319918,
+        },
+        {
+            // Next retarget is at 1152.
+            "9th retarget interval, varying demand, 137th block",
+            {
+                {16, 0, minStakeDiffTestNet},   // 16
+                {127, 20, minStakeDiffTestNet}, // 143
+                {144, 10, minStakeDiffTestNet}, // 287
+                {144, 20, 24055097},            // 431
+                {144, 10, 54516186},            // 575
+                {144, 20, 105335577},           // 719
+                {144, 10, 304330579},           // 863
+                {144, 20, 772249463},           // 1007
+                {76, 10, 2497324513},           // 1083
+                {9, 0, 2497324513},             // 1092
+                {1, 10, 2497324513},            // 1093
+                {8, 0, 2497324513},             // 1101
+                {1, 10, 2497324513},            // 1102
+                {12, 0, 2497324513},            // 1114
+                {1, 10, 2497324513},            // 1115
+                {9, 0, 2497324513},             // 1124
+                {1, 10, 2497324513},            // 1125
+                {8, 0, 2497324513},             // 1133
+                {1, 10, 2497324513},            // 1134
+                {10, 0, 2497324513},            // 1144
+            },
+            10,
+            false,
+            6976183842,
+        },
+        {
+            // Next retarget is at 1440.  The estimated number of
+            // tickets are such that they span the ticket maturity
+            // floor so that the estimation result is slightly
+            // different as compared to what it would be if each
+            // remaining node only had 10 ticket purchases.  This is
+            // because it results in a different number of maturing
+            // tickets depending on how they are allocated on each
+            // side of the maturity floor.
+            "11th retarget interval, 50% demand, 127th block",
+            {
+                {16, 0, minStakeDiffTestNet},   // 16
+                {271, 10, minStakeDiffTestNet}, // 287
+                {144, 10, 22252747},            // 431
+                {144, 10, 27165468},            // 575
+                {144, 10, 39289988},            // 719
+                {144, 10, 66729608},            // 863
+                {144, 10, 116554208},           // 1007
+                {144, 10, 212709675},           // 1151
+                {144, 10, 417424410},           // 1295
+                {127, 10, 876591473},           // 1422
+            },
+            170, // 17 * 10
+            false,
+            1965171141,
+        },
+        {
+            // Next retarget is at 1440.  This is similar to the
+            // last test except all of the estimated tickets are
+            // after the ticket maturity floor, so the estimate is
+            // the same as if each remaining node only had 10 ticket
+            // purchases.
+            "11th retarget interval, 50% demand, 128th block",
+            {
+                {16, 0, minStakeDiffTestNet},   // 16
+                {271, 10, minStakeDiffTestNet}, // 287
+                {144, 10, 22252747},            // 431
+                {144, 10, 27165468},            // 575
+                {144, 10, 39289988},            // 719
+                {144, 10, 66729608},            // 863
+                {144, 10, 116554208},           // 1007
+                {144, 10, 212709675},           // 1151
+                {144, 10, 417424410},           // 1295
+                {128, 10, 876591473},           // 1423
+            },
+            160, // 16 * 10
+            false,
+            1961558695,
+        },
+    };
+
+    EstimateSDiffLoop(tests, testNetParams);
+
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/test_paicoin.cpp
+++ b/src/test/test_paicoin.cpp
@@ -222,7 +222,7 @@ CMutableTransaction Generator::CreateTicketPurchaseTx(const SpendableOut& spend,
     mtx.vout.push_back(CTxOut(ticketPrice, stakeScript));
 
     // create an OP_RETURN push containing a dummy address to send rewards to, and the amount contributed to stake
-    TicketContribData ticketContribData = { 1, rewardAddr, ticketPrice + fee };
+    const auto& ticketContribData = TicketContribData{ 1, rewardAddr, ticketPrice + fee };
     CScript contributorInfoScript = GetScriptForTicketContrib(ticketContribData);
     mtx.vout.push_back(CTxOut(0, contributorInfoScript));
 
@@ -393,7 +393,7 @@ const Consensus::Params& Generator::ConsensusParams() const
 CAmount Generator::NextRequiredStakeDifficulty() const
 {
     CBlock dummyBlock;
-    const auto& ticketPrice = calcNextRequiredStakeDifficulty(dummyBlock, chainActive.Tip(), Params());
+    const auto& ticketPrice = CalculateNextRequiredStakeDifficulty(chainActive.Tip(), Params().GetConsensus());
     return ticketPrice == 0 ? 2e4 : ticketPrice; // nMinimumStakeDiff is set to 0 until CBlockHeader correctly serializes nStakeDifficulty
 }
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -333,6 +333,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
                 pindexNew->nTicketPoolSize = diskindex.nTicketPoolSize;
                 pindexNew->ticketLotteryState = diskindex.ticketLotteryState;
                 pindexNew->nFreshStake    = diskindex.nFreshStake;
+                pindexNew->nStakeVersion  = diskindex.nStakeVersion;
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -502,9 +502,5 @@ std::shared_ptr<StakeNode> FetchStakeNode(CBlockIndex* pindex, const Consensus::
 /** Check existence of address in the address index */
 bool AddressExistsInIndex(const std::string& address);
 
-/** 
- * Get the next stake difficulty
-*/
-CAmount calcNextRequiredStakeDifficulty(const CBlock& block, const CBlockIndex *pindexPrev, const CChainParams& params);
 
 #endif // PAICOIN_VALIDATION_H

--- a/test/functional/rpc_ticket_operations.py
+++ b/test/functional/rpc_ticket_operations.py
@@ -255,8 +255,14 @@ class TicketOperations(PAIcoinTestFramework):
 
         nHeightExpiredBecomeMissed = nTicketExpiry + nStakeEnabledHeight
         assert(nHeightExpiredBecomeMissed > nStakeValidationHeight)
+        nMaxFreshStakePerBlock = 2
 
         for blkidx in range(nStakeValidationHeight, nHeightExpiredBecomeMissed + 10):
+            # purchase tickets
+            print("purchase ", nMaxFreshStakePerBlock, " at ", blkidx)
+            txs.append(self.nodes[0].purchaseticket("", 1.5, 1, txaddress, nMaxFreshStakePerBlock))
+            assert(len(txs[-1])==nMaxFreshStakePerBlock)
+            # winners vote
             winners = self.nodes[0].winningtickets()
             assert(len(winners['tickets'])==nTicketsPerBlock)
             blockhash = chainInfo['bestblockhash']
@@ -268,10 +274,10 @@ class TicketOperations(PAIcoinTestFramework):
             self.sync_all()
             chainInfo = self.nodes[0].getblockchaininfo()
             assert(chainInfo['blocks'] == blkidx)
-            print("generated block ", blkidx)
+            # print("generated block ", blkidx)
 
             x = self.nodes[0].missedtickets()
-            print("missed", x)
+            # print("missed", x)
             assert(blkidx < nHeightExpiredBecomeMissed or len(x["tickets"]) > 0) # we expect missed tickets 
         
 

--- a/test/functional/searchapi.py
+++ b/test/functional/searchapi.py
@@ -17,8 +17,10 @@ from test_framework import util
 
 class SearchAPITest(PAIcoinTestFramework):
     def set_test_params(self):
+        self.setup_clean_chain = True
         self.num_nodes = 1
         self.enable_mocktime()
+        self.extra_args = [['-addrindex']] 
 
     def enable_mocktime (self):
         self.mocktime = 1529934120 # Monday, June 25, 2018 1:42:00 PM GMT
@@ -38,6 +40,7 @@ class SearchAPITest(PAIcoinTestFramework):
         txid = self.nodes[0].sendtoaddress(newaddress, 1)
         assert txid is not None
 
+        self.nodes[0].generate(1)
         self.sync_all()
 
         existsaddr = self.nodes[0].existsaddress(newaddress)
@@ -47,20 +50,21 @@ class SearchAPITest(PAIcoinTestFramework):
         assert not existsaddr
 
     def test_existsaddresses(self):
-        newaddresses = [self.nodes[0].getnewaddress(), self.nodes[0].getnewaddress()]
+        newaddresses = [{'address': self.nodes[0].getnewaddress()}, { 'address' : self.nodes[0].getnewaddress()}]
         assert newaddresses is not None
 
         for newaddr in newaddresses:
-            txid = self.nodes[0].sendtoaddress(newaddr, 1)
+            txid = self.nodes[0].sendtoaddress(newaddr['address'], 1)
             assert txid is not None
 
+        self.nodes[0].generate(1)
         self.sync_all()
 
         existaddrs = self.nodes[0].existsaddresses(newaddresses)
         assert existaddrs is not None
         assert existaddrs == "03" # first 2 bits of a byte showing that both addresses exist
 
-        existsaddrs = self.nodes[0].existsaddresses(["{'address' : 'aaaaa'"])
+        existsaddrs = self.nodes[0].existsaddresses([{'address' : 'aaaaa'}])
         assert existsaddrs is not None
         assert existsaddrs == "00"
 
@@ -71,7 +75,7 @@ class SearchAPITest(PAIcoinTestFramework):
         txid = self.nodes[0].sendtoaddress(newaddress, 1)
         assert txid is not None
 
-        self.sync_all()
+        # self.sync_all()
 
         txhashblob = txid + ("00" * 32) # append one invalid tx hash
         existmempooltxs = self.nodes[0].existsmempooltxs(txhashblob)

--- a/test/functional/stake_api.py
+++ b/test/functional/stake_api.py
@@ -46,7 +46,10 @@ class StakeAPITest(PAIcoinTestFramework):
 
         result = chain_node.estimatestakediff()
         assert result is not None
-        assert 'user' not in result.keys()
+        assert 'min' in result.keys()
+        assert 'max' in result.keys()
+        assert 'expected' in result.keys()
+        assert(result['user'] == 0)
 
         util.assert_raises_rpc_error(-8, None, chain_node.estimatestakediff, -1)
         util.assert_raises_rpc_error(-1, None, chain_node.estimatestakediff, 1, 5)
@@ -123,13 +126,14 @@ class StakeAPITest(PAIcoinTestFramework):
         util.assert_raises_rpc_error(-8, None, chain_node.getstakeversions, "aa", -1)
         util.assert_raises_rpc_error(-8, None, chain_node.getstakeversions, "zz", -1)
 
+        info = self.nodes[0].getblockchaininfo()
         numBlocks = 1
-        result = chain_node.getstakeversions("aa", numBlocks)
+        result = chain_node.getstakeversions(info['bestblockhash'], numBlocks)
         assert result is not None
         assert self._check_getstakeversions_result(result, numBlocks)
 
         numBlocks = 3
-        result = chain_node.getstakeversions("bb", numBlocks)
+        result = chain_node.getstakeversions(info['bestblockhash'], numBlocks)
         assert result is not None
         assert self._check_getstakeversions_result(result, numBlocks)
 


### PR DESCRIPTION
* ported function to calculate estimate stake difficulty
* added unit test for the new estimate function
* integrated stakeversion changes
* implemented 'getstakedifficulty', 'getstakeversioninfo', 'getstakeversions'
* fixed functional tests: stake_api, searchapi, infoop
* re-enabled tests that purchase tickets after stake validation height
* added flag to identify address type in reward script(Issue #63)