### PR TITLE
Issue #286: Implement additional functional tests for post-fork behav…

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -288,6 +288,7 @@ libpaicoin_consensus_a_SOURCES = \
   amount.h \
   arith_uint256.cpp \
   arith_uint256.h \
+  chainparams.cpp \
   consensus/merkle.cpp \
   consensus/merkle.h \
   consensus/params.h \
@@ -338,7 +339,6 @@ libpaicoin_common_a_CPPFLAGS = $(AM_CPPFLAGS) $(PAICOIN_INCLUDES)
 libpaicoin_common_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libpaicoin_common_a_SOURCES = \
   base58.cpp \
-  chainparams.cpp \
   coins.cpp \
   compressor.cpp \
   core_read.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -135,7 +135,7 @@ public:
         consensus.BIP34Height = 1;  // BIP34 is activated from the genesis block
         consensus.BIP65Height = 1;  // BIP65 is activated from the genesis block
         consensus.BIP66Height = 1;  // BIP66 is activated from the genesis block
-        consensus.HybridConsensusForkTime = -1; // Never
+        consensus.HybridConsensusHeight = -1; // Never
         consensus.powLimit = MAINNET_CONSENSUS_POW_LIMIT;
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -298,7 +298,7 @@ public:
         consensus.BIP34Height = 1;  // BIP34 is activated from the genesis block
         consensus.BIP65Height = 1;  // BIP65 is activated from the genesis block
         consensus.BIP66Height = 1;  // BIP66 is activated from the genesis block
-        consensus.HybridConsensusForkTime = -1; // Never
+        consensus.HybridConsensusHeight = -1; // Never
         consensus.powLimit = TESTNET_CONSENSUS_POW_LIMIT;
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -460,7 +460,7 @@ public:
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
         consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
-        consensus.HybridConsensusForkTime = 1500;
+        consensus.HybridConsensusHeight = 1500;
         consensus.powLimit = REGTEST_CONSENSUS_POW_LIMIT;
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -62,8 +62,8 @@ struct Params {
     int BIP65Height;
     /** Block height at which BIP66 becomes active */
     int BIP66Height;
-    /** Earliest block median time past at which hardfork may become active */
-    int64_t HybridConsensusForkTime;
+    /** Block height at which Hybrid Consensus becomes active */
+    int HybridConsensusHeight;
     /**
      * Minimum blocks including miner confirmation of the total of 2016 blocks in a retargeting period,
      * (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -21,6 +21,7 @@
 #include <sys/stat.h>
 #include <signal.h>
 #include <future>
+#include <deque>
 
 #include <event2/thread.h>
 #include <event2/buffer.h>

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -10,12 +10,15 @@
 #include "utilstrencodings.h"
 #include "stake/staketx.h"
 #include "crypto/common.h"
+#include "chainparams.h"
 
 uint256 CBlockHeader::GetHash() const
 {
+    if (this->nVersion & HARDFORK_VERSION_BIT) {
+        // use SHAKE-256 hasher when Hybrid PoW/PoS deploys
+        return SerializeHash<CBlockHashWriter>(*this);
+    }
     return SerializeHash<CHashWriter>(*this);
-    // TODO: use CBlockHashWriter as template argument and regenerate the GENESIS BLOCK
-    // return SerializeHash<CBlockHashWriter>(*this);
 }
 
 std::string CBlock::ToString() const
@@ -35,4 +38,18 @@ std::string CBlock::ToString() const
         s << "  " << tx->ToString() << "\n";
     }
     return s.str();
+}
+
+void CBlockHeader::SetReadStakeDefaultBeforeFork()
+{
+    nStakeDifficulty = Params().GetConsensus().nMinimumStakeDiff;
+    // TODO add more stake defaults as needed
+    // nVoteBits = 1;
+    // nTicketPoolSize = 0;
+    // ticketLotteryState.SetNull();
+    // nVoters = 0;
+    // nFreshStake = 0;
+    // nRevocations = 0;
+    // std::fill(std::begin(extraData), std::end(extraData), 0);
+    // nStakeVersion = 0;
 }

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -67,7 +67,13 @@ public:
             READWRITE(FLATDATA(extraData));
             READWRITE(nStakeVersion);
         }
+        else if (ser_action.ForRead())
+        {
+           SetReadStakeDefaultBeforeFork(); 
+        }
     }
+
+    void SetReadStakeDefaultBeforeFork();
 
     void SetNull()
     {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3390,7 +3390,7 @@ bool IsWitnessEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& pa
 bool IsHybridConsensusForkEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& params)
 {
     AssertLockHeld(cs_main);
-    return (params.HybridConsensusForkTime >= 0 && pindexPrev && pindexPrev->GetMedianTimePast() >= params.HybridConsensusForkTime && pindexPrev->nHeight >= params.BIP65Height);
+    return (params.HybridConsensusHeight >= 0 && pindexPrev && pindexPrev->nHeight >= params.HybridConsensusHeight);
 }
 
 // Compute at which vout of the block's coinbase transaction the witness

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3457,7 +3457,6 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
     assert(pindexPrev != nullptr);
     const int nHeight = pindexPrev->nHeight + 1;
     const Consensus::Params& consensusParams = params.GetConsensus();
-    const bool hybridForkEnabled = IsHybridConsensusForkEnabled(pindexPrev, consensusParams);
 
     // Check proof of work
     if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams))
@@ -3465,12 +3464,10 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
 
     // Ensure the stake difficulty specified in the block header matches the calculated difficulty based on the previous block
     // and difficulty retarget rules.
-    if (hybridForkEnabled) {
-        CAmount expectedStakeDifficulty = CalculateNextRequiredStakeDifficulty(pindexPrev, params.GetConsensus());
-        if (block.nStakeDifficulty != expectedStakeDifficulty) {
-            auto report = strprintf("incorrect stake difficulty in a block: expected %.2f, found %.2f", expectedStakeDifficulty / (float)COIN, block.nStakeDifficulty / (float)COIN);
-            return state.DoS(100, false, REJECT_INVALID, "bad-stakediff", false, report);
-        }
+    CAmount expectedStakeDifficulty = CalculateNextRequiredStakeDifficulty(pindexPrev, params.GetConsensus());
+    if (block.nStakeDifficulty != expectedStakeDifficulty) {
+        auto report = strprintf("incorrect stake difficulty in a block: expected %.2f, found %.2f", expectedStakeDifficulty / (float)COIN, block.nStakeDifficulty / (float)COIN);
+        return state.DoS(100, false, REJECT_INVALID, "bad-stakediff", false, report);
     }
 
     auto expectedStakeVersion = calcStakeVersion(pindexPrev, params.GetConsensus());
@@ -3511,6 +3508,7 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
     if (block.GetBlockTime() > nAdjustedTime + MAX_FUTURE_BLOCK_TIME)
         return state.Invalid(false, REJECT_INVALID, "time-too-new", "block timestamp too far in the future");
 
+    const bool hybridForkEnabled = IsHybridConsensusForkEnabled(pindexPrev, consensusParams);
     if (hybridForkEnabled) {
         if (block.nVersion & HARDFORK_VERSION_BIT)
             return true;

--- a/test/functional/multinode_hybrid_fork.py
+++ b/test/functional/multinode_hybrid_fork.py
@@ -27,7 +27,7 @@ class MultinodeHybridConsensusFork(PAIcoinTestFramework):
         connect_nodes_bi(self.nodes,0,1)
 
     def run_test(self):
-        HybridForkHeight = 1352
+        HybridForkHeight = 1501 # in chainparams.cpp -> consensus.HybridConsensusHeight = 1500;
         StakeValidationHeight = 2100
         MinimumStakeDiff = Decimal('0.0002')
 
@@ -58,13 +58,13 @@ class MultinodeHybridConsensusFork(PAIcoinTestFramework):
         stakeDiff = self.nodes[0].getstakedifficulty()
         assert(stakeDiff['current'] == MinimumStakeDiff)
 
-        self.nodes[0].generate(300)
+        self.nodes[0].generate(400)
         self.sync_all()
 
         nMaxFreshStakePerBlock = 20
         txaddress = self.nodes[0].getnewaddress()
         txs = []
-        for blkidx in range(HybridForkHeight + 301, StakeValidationHeight):
+        for blkidx in range(HybridForkHeight + 401, StakeValidationHeight):
             print("purchase", nMaxFreshStakePerBlock, "at", blkidx)
             txs.append(self.nodes[0].purchaseticket("", 1.5, 1, txaddress, nMaxFreshStakePerBlock))
             assert(len(txs[-1])==nMaxFreshStakePerBlock)

--- a/test/functional/multinode_hybrid_fork.py
+++ b/test/functional/multinode_hybrid_fork.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Test that purchases tickets after the Hybrid Consensus Fork height
+on one of the nodes then expects the sync_all to timeout
+    - when tickets are purchased the stake difficulty is automatically adjusted
+    - after the fork we use an extended block header that carries the adjusted stake difficulty to other nodes
+    - the other nodes apply the validation rules, and knowing the adjusted value, the
+stake difficulty does not fail
+    - see multinode_tickets_before_hybrid_fork.py for the scenario that buys before the fork
+"""
+
+from test_framework.test_framework import PAIcoinTestFramework
+from test_framework.util import *
+from test_framework.mininode import COIN
+
+class MultinodeHybridConsensusFork(PAIcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def setup_network(self, split=False):
+        super().setup_network()
+        connect_nodes_bi(self.nodes,0,1)
+
+    def run_test(self):
+        HybridForkHeight = 1352
+        StakeValidationHeight = 2100
+        MinimumStakeDiff = Decimal('0.0002')
+
+        self.nodes[0].generate(1000)
+        self.sync_all()
+        info = self.nodes[0].getblockchaininfo()
+        assert(info['blocks'] == 1000)
+        blockinfo = self.nodes[0].getblock(info['bestblockhash'])
+        assert(blockinfo['version'] ==  536870912)
+
+        self.nodes[0].generate(HybridForkHeight - 1000 - 1)
+        self.sync_all()
+        info = self.nodes[0].getblockchaininfo()
+        # block height just before hybrid fork
+        assert(info['blocks'] == HybridForkHeight - 1)
+        blockinfo = self.nodes[0].getblock(info['bestblockhash'])
+        assert(blockinfo['version'] ==  536870912)
+
+        # block height just after hybrid fork
+        self.nodes[0].generate(1)
+        self.sync_all()
+        info = self.nodes[0].getblockchaininfo()
+        # block height just after hybrid fork
+        assert(info['blocks'] == HybridForkHeight)
+        blockinfo = self.nodes[0].getblock(info['bestblockhash'])
+        assert(blockinfo['version'] == -1610612736) # we change the sign bit of the version at fork
+
+        stakeDiff = self.nodes[0].getstakedifficulty()
+        assert(stakeDiff['current'] == MinimumStakeDiff)
+
+        self.nodes[0].generate(300)
+        self.sync_all()
+
+        nMaxFreshStakePerBlock = 20
+        txaddress = self.nodes[0].getnewaddress()
+        txs = []
+        for blkidx in range(HybridForkHeight + 301, StakeValidationHeight):
+            print("purchase", nMaxFreshStakePerBlock, "at", blkidx)
+            txs.append(self.nodes[0].purchaseticket("", 1.5, 1, txaddress, nMaxFreshStakePerBlock))
+            assert(len(txs[-1])==nMaxFreshStakePerBlock)
+
+            self.nodes[0].generate(1)
+            chainInfo = self.nodes[0].getblockchaininfo()
+            assert(chainInfo['blocks'] == blkidx)
+
+            stakeDiff = self.nodes[0].getstakedifficulty()
+            print("stake difficulty at", blkidx, "is", stakeDiff)
+            if stakeDiff['current'] > MinimumStakeDiff:
+                break
+
+        # check that after hybrid fork we can sync the two nodes while buying tickets
+        # this means that the extended BlockHeader is transmitted correctly
+        self.sync_all()
+
+if __name__ == '__main__':
+    MultinodeHybridConsensusFork().main()

--- a/test/functional/multinode_tickets_before_hybrid_fork.py
+++ b/test/functional/multinode_tickets_before_hybrid_fork.py
@@ -28,7 +28,7 @@ class MultinodeHybridConsensusForkWithTickets(PAIcoinTestFramework):
 
     def run_test(self):
         MinimumStakeDiff = Decimal('0.0002')
-        HybridForkHeight = 1352
+        HybridForkHeight = 1501 # in chainparams.cpp -> consensus.HybridConsensusHeight = 1500;
         BlockHeightBeforeBuy = 900
         assert(BlockHeightBeforeBuy < HybridForkHeight)
 

--- a/test/functional/multinode_tickets_before_hybrid_fork.py
+++ b/test/functional/multinode_tickets_before_hybrid_fork.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2016 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+"""
+Test that intentionally purchases tickets before the Hybrid Consensus Fork height
+on one of the nodes then expects the sync_all to timeout
+    - when tickets are purchased the stake difficulty is automatically adjusted
+    - before the fork we have no way of sending the adjusted stake difficulty to other nodes
+    - the other nodes apply the validation rules, but not knowing the adjusted value, the
+stake difficulty check fails
+    - see multinode_hybrid_fork.py for the scenario that buys after the fork
+"""
+
+from test_framework.test_framework import PAIcoinTestFramework
+from test_framework.util import *
+from test_framework.mininode import COIN
+
+class MultinodeHybridConsensusForkWithTickets(PAIcoinTestFramework):
+    def set_test_params(self):
+        self.setup_clean_chain = True
+        self.num_nodes = 2
+
+    def setup_network(self, split=False):
+        super().setup_network()
+        connect_nodes_bi(self.nodes,0,1)
+
+    def run_test(self):
+        MinimumStakeDiff = Decimal('0.0002')
+        HybridForkHeight = 1352
+        BlockHeightBeforeBuy = 900
+        assert(BlockHeightBeforeBuy < HybridForkHeight)
+
+        self.nodes[0].generate(BlockHeightBeforeBuy)
+        self.sync_all()
+        info = self.nodes[1].getblockchaininfo()
+        assert(info['blocks'] == BlockHeightBeforeBuy)
+        blockinfo = self.nodes[1].getblock(info['bestblockhash'])
+        assert(blockinfo['version'] ==  536870912)
+
+        stakeDiff = self.nodes[0].getstakedifficulty()
+        assert(stakeDiff['current'] == MinimumStakeDiff)
+
+        nMaxFreshStakePerBlock = 20
+        txaddress = self.nodes[0].getnewaddress()
+        txs = []
+        for blkidx in range(BlockHeightBeforeBuy + 1, HybridForkHeight):
+            print("purchase", nMaxFreshStakePerBlock, "at", blkidx)
+            txs.append(self.nodes[0].purchaseticket("", 1.5, 1, txaddress, nMaxFreshStakePerBlock))
+            assert(len(txs[-1])==nMaxFreshStakePerBlock)
+
+            self.nodes[0].generate(1)
+            chainInfo = self.nodes[0].getblockchaininfo()
+            assert_equal(chainInfo['blocks'], blkidx)
+
+            stakeDiff = self.nodes[0].getstakedifficulty()
+            print("stake difficulty at", blkidx, "is", stakeDiff)
+            if stakeDiff['current'] > MinimumStakeDiff:
+                break
+
+        # check that having ticket purchases before the fork the nodes cannnot sync 
+        assert_raises(AssertionError, lambda: self.sync_all())
+
+if __name__ == '__main__':
+    MultinodeHybridConsensusForkWithTickets().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -61,12 +61,14 @@ BASE_SCRIPTS= [
     'fundrawtransaction.py',
     'p2p-compactblocks.py',
     'segwit.py',
+    'rpc_ticket_operations.py',
     # vv Tests less than 2m vv
     'wallet.py',
     'wallet-accounts.py',
     'p2p-segwit.py',
     'wallet-dump.py',
     'listtransactions.py',
+    'multinode_tickets_before_hybrid_fork.py',
     # vv Tests less than 60s vv
     'sendheaders.py',
     'zapwallettxes.py',
@@ -130,9 +132,9 @@ BASE_SCRIPTS= [
     'wallet_stake_api.py',
     'wallet_multisig_api.py',
     'wallet_ticket_api.py',
-    'rpc_ticket_operations.py',
     'rpc_search_operations.py',
-    'rpc_node_operations.py'
+    'rpc_node_operations.py',
+    'multinode_hybrid_fork.py',
 ]
 
 EXTENDED_SCRIPTS = [


### PR DESCRIPTION
…iors

* added multinode test that purchases tickets after the hardfork, expecting to sync correctly
* added default stake value when deserializating BlockHeader
* added multinode test that purchases tickets before the hardfork, expecting sync to fail
* used the new SHAKE-256 hasher when hardfork activates