### PR TITLE
fix build for Boost libraries after Catalina 10.15

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -3,6 +3,7 @@ $(package)_version=1_64_0
 $(package)_download_path=https://dl.bintray.com/boostorg/release/1.64.0/source/
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332
+$(package)_patches=40960b23338da0a359d6aa83585ace09ad8804d2.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
@@ -25,7 +26,8 @@ $(package)_cxxflags_linux=-fPIC
 endef
 
 define $(package)_preprocess_cmds
-  echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
+  echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam && \
+  patch -p0 < $($(package)_patch_dir)/40960b23338da0a359d6aa83585ace09ad8804d2.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/boost/40960b23338da0a359d6aa83585ace09ad8804d2.patch
+++ b/depends/patches/boost/40960b23338da0a359d6aa83585ace09ad8804d2.patch
@@ -1,0 +1,31 @@
+From 40960b23338da0a359d6aa83585ace09ad8804d2 Mon Sep 17 00:00:00 2001
+From: Bo Anderson <mail@boanderson.me>
+Date: Sun, 29 Mar 2020 14:55:08 +0100
+Subject: [PATCH] Fix compiler version check on macOS
+
+Fixes #440.
+---
+ tools/build/src/tools/darwin.jam | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/tools/darwin.jam b/src/tools/darwin.jam
+index 8d477410b0..97e7ecb851 100644
+--- ./tools/build/src/tools/darwin.jam
++++ ./tools/build/src/tools/darwin.jam
+@@ -137,13 +137,14 @@ rule init ( version ? : command * : options * : requirement * )
+     # - Set the toolset generic common options.
+     common.handle-options darwin : $(condition) : $(command) : $(options) ;
+     
++    real-version = [ regex.split $(real-version) \\. ] ;
+     # - GCC 4.0 and higher in Darwin does not have -fcoalesce-templates.
+-    if $(real-version) < "4.0.0"
++    if [ version.version-less $(real-version) : 4 0 ]
+     {
+         flags darwin.compile.c++ OPTIONS $(condition) : -fcoalesce-templates ;
+     }
+     # - GCC 4.2 and higher in Darwin does not have -Wno-long-double.
+-    if $(real-version) < "4.2.0"
++    if [ version.version-less $(real-version) : 4 2 ]
+     {
+         flags darwin.compile OPTIONS $(condition) : -Wno-long-double ;
+     }

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -34,7 +34,17 @@ Build PAI Coin Core
         git clone https://github.com/projectpai/paicoin
         cd paicoin
 
-2.  Build paicoin-core:
+2. If you have Catalina 10.15 or a higher version, then you must run this command:
+
+	If you have XCode installed:
+
+	export CPATH=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
+
+	If you have only the command-line tools:
+
+	CPATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/
+
+3.  Build paicoin-core:
 
     Configure and build the headless paicoin binaries as well as the GUI (if Qt is found).
 
@@ -47,11 +57,11 @@ Build PAI Coin Core
         CONFIG_SITE=`pwd`/depends/`build-aux/config.guess`/share/config.site ./configure
         make
 
-3.  It is recommended to build and run the unit tests:
+4.  It is recommended to build and run the unit tests:
 
         make check
 
-4.  You can also create a .dmg that contains the .app bundle (optional):
+5.  You can also create a .dmg that contains the .app bundle (optional):
 
         make deploy
 


### PR DESCRIPTION
After the Catalina 10.15 OS update from Apple, we cannot longer build `depends`. Boost libraries fail to build.