### PR TITLE
Updates for external mining on hybrid consensus

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -362,6 +362,43 @@ Wallet options:
        blockchain through -rescan on startup (1 = keep tx meta data e.g.
        account owner and payment request information, 2 = drop tx meta data)
 
+  -autostake
+       Enable the automatic ticket buyer, the automatic voter and the automatic
+       revoker. These are performing the staking operations on behalf of the user
+       and as soon as possible. Please note that the ticket buyer requires more
+       settings to perform correctly, such as -tbvotingaddress, -tblimit or
+       -tbbalancetomaintainabsolute.
+
+  -autobuy
+       Enable the automatic ticket buyer. This is purchasing tickets on behalf of
+       the user as soon as all the criteria is met. Please make sure to specify
+       the voting address and other parameters as desired.
+
+  -tbbalancetomaintainabsolute
+       The funds to preserve in the wallet when purchasing tickets. This ensures
+       that at least this amount is still available in the wallet. No purchase
+       is made if the funds for tickets are not enough.
+
+  -tbvotingaddress
+       Specify the address to be used when voting. The voter or revoker must be
+       able to sign the input corresponding to this output, so it must own the
+       address.
+
+  -tblimit
+       The maximum number of tickets to purchase in one batch.
+
+  -tbvotingaccount
+       Specify the account to be used for voting.
+
+  -autovote
+       Enable the automatic voter. This is going to send the votes for the tickets
+       belonging to the wallet as soon as they are selected as winners.
+
+  -autorevoke
+     Enable the automatic revoker. As soon as a ticket becomes expired or missed,
+     the automatic revoker creates and publishes a transaction that is unlocking the
+     staked funds.
+
 Debugging/Testing options:
 
   -checkpoints

--- a/src/help.txt
+++ b/src/help.txt
@@ -268,6 +268,43 @@ Wallet options:
        account owner and payment request information, 2 = drop tx meta
        data)
 
+  -autostake
+       Enable the automatic ticket buyer, the automatic voter and the automatic
+       revoker. These are performing the staking operations on behalf of the user
+       and as soon as possible. Please note that the ticket buyer requires more
+       settings to perform correctly, such as -tbvotingaddress, -tblimit or
+       -tbbalancetomaintainabsolute.
+
+  -autobuy
+       Enable the automatic ticket buyer. This is purchasing tickets on behalf of
+       the user as soon as all the criteria is met. Please make sure to specify
+       the voting address and other parameters as desired.
+
+  -tbbalancetomaintainabsolute
+       The funds to preserve in the wallet when purchasing tickets. This ensures
+       that at least this amount is still available in the wallet. No purchase
+       is made if the funds for tickets are not enough.
+
+  -tbvotingaddress
+       Specify the address to be used when voting. The voter or revoker must be
+       able to sign the input corresponding to this output, so it must own the
+       address.
+
+  -tblimit
+       The maximum number of tickets to purchase in one batch.
+
+  -tbvotingaccount
+       Specify the account to be used for voting.
+
+  -autovote
+       Enable the automatic voter. This is going to send the votes for the tickets
+       belonging to the wallet as soon as they are selected as winners.
+
+  -autorevoke
+       Enable the automatic revoker. As soon as a ticket becomes expired or missed,
+       the automatic revoker creates and publishes a transaction that is unlocking the
+       staked funds.
+
 ZeroMQ notification options:
 
   -zmqpubhashblock=<address>

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -43,13 +43,12 @@ std::string CBlock::ToString() const
 void CBlockHeader::SetReadStakeDefaultBeforeFork()
 {
     nStakeDifficulty = Params().GetConsensus().nMinimumStakeDiff;
-    // TODO add more stake defaults as needed
-    // nVoteBits = VoteBits::rttAccepted;
-    // nTicketPoolSize = 0;
-    // ticketLotteryState.SetNull();
-    // nVoters = 0;
-    // nFreshStake = 0;
-    // nRevocations = 0;
-    // std::fill(std::begin(extraData), std::end(extraData), 0);
-    // nStakeVersion = 0;
+    nVoteBits = VoteBits::rttAccepted;
+    nTicketPoolSize = 0;
+    ticketLotteryState.SetNull();
+    nVoters = 0;
+    nFreshStake = 0;
+    nRevocations = 0;
+    std::fill(std::begin(extraData), std::end(extraData), 0);
+    nStakeVersion = 0;
 }

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -147,18 +147,21 @@ public:
     CBlockHeader GetBlockHeader() const
     {
         CBlockHeader block;
-        block.nVersion       = nVersion;
-        block.hashPrevBlock  = hashPrevBlock;
-        block.hashMerkleRoot = hashMerkleRoot;
-        block.nTime          = nTime;
-        block.nBits          = nBits;
-        block.nNonce         = nNonce;
-        block.nVoteBits      = nVoteBits;
-        block.nStakeDifficulty = nStakeDifficulty;
-        block.nTicketPoolSize = nTicketPoolSize;
-        block.ticketLotteryState = ticketLotteryState;
-        block.nFreshStake    = nFreshStake;
-        block.nStakeVersion  = nStakeVersion;
+        block.nVersion              = nVersion;
+        block.hashPrevBlock         = hashPrevBlock;
+        block.hashMerkleRoot        = hashMerkleRoot;
+        block.nTime                 = nTime;
+        block.nBits                 = nBits;
+        block.nNonce                = nNonce;
+        block.nVoteBits             = nVoteBits;
+        block.nStakeDifficulty      = nStakeDifficulty;
+        block.nTicketPoolSize       = nTicketPoolSize;
+        block.ticketLotteryState    = ticketLotteryState;
+        block.nVoters               = nVoters;
+        block.nFreshStake           = nFreshStake;
+        block.nRevocations          = nRevocations;
+        std::copy(extraData, extraData+sizeof(extraData), block.extraData);
+        block.nStakeVersion         = nStakeVersion;
         return block;
     }
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -678,12 +678,21 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
     result.push_back(Pair("height", static_cast<int64_t>((pindexPrev->nHeight+1))));
 
     if (IsHybridConsensusForkEnabled(pindexPrev, Params().GetConsensus())) {
-        result.push_back(Pair("stakedifficulty", std::to_string(pblock->nStakeDifficulty)));
-        result.push_back(Pair("votebits", strprintf("%04x", pblock->nVoteBits.getBits())));
-        result.push_back(Pair("ticketpoolsize", strprintf("%08x", pblock->nTicketPoolSize)));
+        // large values are not correctly interpreted by the miner, thus we use hex strings where needed
+        result.push_back(Pair("stakedifficulty", strprintf("%016x", pblock->nStakeDifficulty)));
+        result.push_back(Pair("votebits", pblock->nVoteBits.getBits()));
+        result.push_back(Pair("ticketpoolsize", static_cast<int64_t>(pblock->nTicketPoolSize)));
         result.push_back(Pair("ticketlotterystate", StakeStateToString(pblock->ticketLotteryState)));
-        result.push_back(Pair("stakeversion", strprintf("%08x", pblock->nStakeVersion)));
+        result.push_back(Pair("voters", pblock->nVoters));
         result.push_back(Pair("freshstake", pblock->nFreshStake));
+        result.push_back(Pair("revocations", pblock->nRevocations));
+
+        std::string extraData;
+        for (auto& byte: pblock->extraData)
+            extraData += strprintf("%02x", byte);
+        result.push_back(Pair("extradata", extraData));
+
+        result.push_back(Pair("stakeversion", static_cast<int64_t>(pblock->nStakeVersion)));
     }
 
     if (!pblocktemplate->vchCoinbaseCommitment.empty() && fSupportsSegwit) {

--- a/src/stake/stakenode.cpp
+++ b/src/stake/stakenode.cpp
@@ -1,12 +1,13 @@
 #include "stake/stakenode.h"
 #include "stake/hash256prng.h"
 #include "hash.h"
+#include "tinyformat.h"
 
 std::string StakeStateToString(const StakeState& stakeState)
 {
     std::string str;
     for (auto c : stakeState)
-        str += std::to_string((int)c) + " ";
+        str += strprintf("%02x", c);
     return str;
 }
 

--- a/src/wallet/auto-revoker/autorevokerconfig.cpp
+++ b/src/wallet/auto-revoker/autorevokerconfig.cpp
@@ -12,6 +12,4 @@ CAutoRevokerConfig::CAutoRevokerConfig() :
 
 void CAutoRevokerConfig::ParseCommandline()
 {
-    if (gArgs.IsArgSet("-autoRevoke"))
-        autoRevoke = gArgs.GetBoolArg("-autoRevoke", false);
 }

--- a/src/wallet/auto-voter/autovoterconfig.cpp
+++ b/src/wallet/auto-voter/autovoterconfig.cpp
@@ -13,6 +13,19 @@ CAutoVoterConfig::CAutoVoterConfig() :
 
 void CAutoVoterConfig::ParseCommandline()
 {
-    if (gArgs.IsArgSet("-autoVote"))
-        autoVote = gArgs.GetBoolArg("-autoVote", false);
+    if (gArgs.IsArgSet("-avvotebits")) {
+        int64_t vb = gArgs.GetArg("-avvotebits", 1);
+        if (vb >= std::numeric_limits<uint16_t>().min() || vb <= std::numeric_limits<uint16_t>().max())
+            voteBits = VoteBits(static_cast<uint16_t>(vb));
+        else
+            LogPrintf("ERROR: automatic vote bits out of range %lld. Using default: %d", vb, VoteBits().getBits());
+    }
+
+    if (gArgs.IsArgSet("-avextendedvotebits")) {
+        std::string evb = gArgs.GetArg("-avextendedvotebits", "");
+        if (ExtendedVoteBits::containsValidExtendedVoteBits(evb))
+            extendedVoteBits = ExtendedVoteBits(evb);
+        else
+            LogPrintf("ERROR: automatic extended vote bits are note valid %s. Using default: %s", evb, ExtendedVoteBits().getHex());
+    }
 }

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -38,6 +38,14 @@ std::string GetWalletHelpString(bool showDebug)
     strUsage += HelpMessageOpt("-walletnotify=<cmd>", _("Execute command when a wallet transaction changes (%s in cmd is replaced by TxID)"));
     strUsage += HelpMessageOpt("-zapwallettxes=<mode>", _("Delete all wallet transactions and only recover those parts of the blockchain through -rescan on startup") +
                                " " + _("(1 = keep tx meta data e.g. account owner and payment request information, 2 = drop tx meta data)"));
+    strUsage += HelpMessageOpt("-autostake", strprintf(_("Enable the automatic ticket buyer, the automatic voter and the automatic revoker. These are performing the staking operations on behalf of the user and as soon as possible. Please note that the ticket buyer requires more settings to perform correctly, such as -tbvotingaddress, -tblimit or -tbbalancetomaintainabsolute. (default: %u)"), false));
+    strUsage += HelpMessageOpt("-autobuy", strprintf(_("Enable the automatic ticket buyer. This is purchasing tickets on behalf of the user as soon as all the criteria is met. Please make sure to specify the voting address and other parameters as desired. (default: %u)"), DEFAULT_AUTO_BUY));
+    strUsage += HelpMessageOpt("-tbbalancetomaintainabsolute", strprintf(_("The funds to preserve in the wallet when purchasing tickets. This ensures that at least this amount is still available in the wallet. No purchase is made if the funds for tickets are not enough.")));
+    strUsage += HelpMessageOpt("-tbvotingaddress", strprintf(_("Specify the address to be used when voting. The voter or revoker must be able to sign the input corresponding to this output, so it must own the address.")));
+    strUsage += HelpMessageOpt("-tblimit", strprintf(_("The maximum number of tickets to purchase in one batch.")));
+    strUsage += HelpMessageOpt("-tbvotingaccount", strprintf(_("Specify the account to be used for voting.")));
+    strUsage += HelpMessageOpt("-autovote", strprintf(_("Enable the automatic voter. This is going to send the votes for the tickets belonging to the wallet as soon as they are selected as winners. (default: %u)"), DEFAULT_AUTO_VOTE));
+    strUsage += HelpMessageOpt("-autorevoke", strprintf(_("Enable the automatic revoker. As soon as a ticket becomes expired or missed, the automatic revoker creates and publishes a transaction that is unlocking the staked funds. (default: %u)"), DEFAULT_AUTO_REVOKE));
 
     if (showDebug)
     {
@@ -168,6 +176,10 @@ bool WalletParameterInteraction()
     nTxConfirmTarget = gArgs.GetArg("-txconfirmtarget", DEFAULT_TX_CONFIRM_TARGET);
     bSpendZeroConfChange = gArgs.GetBoolArg("-spendzeroconfchange", DEFAULT_SPEND_ZEROCONF_CHANGE);
     fWalletRbf = gArgs.GetBoolArg("-walletrbf", DEFAULT_WALLET_RBF);
+
+    fAutoBuy = gArgs.GetBoolArg("-autobuy", false) || (!gArgs.IsArgSet("-autobuy") && gArgs.GetBoolArg("-autostake", false));
+    fAutoVote = gArgs.GetBoolArg("-autovote", false) || (!gArgs.IsArgSet("-autovote") && gArgs.GetBoolArg("-autostake", false));
+    fAutoRevoke = gArgs.GetBoolArg("-autorevoke", false) || (!gArgs.IsArgSet("-autorevoke") && gArgs.GetBoolArg("-autostake", false));
 
     return true;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -45,6 +45,10 @@ unsigned int nTxConfirmTarget = DEFAULT_TX_CONFIRM_TARGET;
 bool bSpendZeroConfChange = DEFAULT_SPEND_ZEROCONF_CHANGE;
 bool fWalletRbf = DEFAULT_WALLET_RBF;
 
+bool fAutoBuy = DEFAULT_AUTO_BUY;
+bool fAutoVote = DEFAULT_AUTO_VOTE;
+bool fAutoRevoke = DEFAULT_AUTO_REVOKE;
+
 const char * DEFAULT_WALLET_DAT = "wallet.dat";
 const uint32_t BIP32_HARDENED_KEY_LIMIT = 0x80000000;
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -45,6 +45,10 @@ extern unsigned int nTxConfirmTarget;
 extern bool bSpendZeroConfChange;
 extern bool fWalletRbf;
 
+extern bool fAutoBuy;
+extern bool fAutoVote;
+extern bool fAutoRevoke;
+
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 1000;
 //! -paytxfee default
 static const CAmount DEFAULT_TRANSACTION_FEE = 0;
@@ -68,6 +72,12 @@ static const bool DEFAULT_WALLET_REJECT_LONG_CHAINS = false;
 static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 6;
 //! -walletrbf default
 static const bool DEFAULT_WALLET_RBF = false;
+//! -autobuy default
+static const bool DEFAULT_AUTO_BUY = false;
+//! -autovote default
+static const bool DEFAULT_AUTO_VOTE = false;
+//! -autorevoke default
+static const bool DEFAULT_AUTO_REVOKE = false;
 static const bool DEFAULT_WALLETBROADCAST = true;
 static const bool DEFAULT_DISABLE_WALLET = false;
 //! if set, all keys will be derived by using BIP32
@@ -804,8 +814,11 @@ public:
         ticketFeeRate(2 * minTxFee.GetFeePerK())
     {
         autoVoter = MakeUnique<CAutoVoter>(this);
+        if (fAutoVote) autoVoter->start();
         autoRevoker = MakeUnique<CAutoRevoker>(this);
+        if (fAutoRevoke) autoRevoker->start();
         ticketBuyer = MakeUnique<CTicketBuyer>(this);
+        ticketBuyer->GetConfig().buyTickets = fAutoBuy;
         SetNull();
     }
 
@@ -815,8 +828,11 @@ public:
         ticketFeeRate(2 * minTxFee.GetFeePerK())
     {
         autoVoter = MakeUnique<CAutoVoter>(this);
+        if (fAutoVote) autoVoter->start();
         autoRevoker = MakeUnique<CAutoRevoker>(this);
+        if (fAutoRevoke) autoRevoker->start();
         ticketBuyer = MakeUnique<CTicketBuyer>(this);
+        ticketBuyer->GetConfig().buyTickets = fAutoBuy;
         SetNull();
     }
 


### PR DESCRIPTION
This PR contains minor changes required to allow mining via the RPC calls:
- implemented command line parameters to enable the automatic ticket buyer, voter and revoker;
- improvements in pre-conditions for  the automatic ticket buyer, voter and revoker;
- initialization of stake parameters in the block header;
- reformatted some getblocktemplate response stake parameters;
- added missing stake parameters in getblocktemplate response.