### PR TITLE
Added filtration of tickets with low stake difficulty

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -197,6 +197,17 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         for (auto tickettxiter = existingTickets.first; tickettxiter != existingTickets.second; ++tickettxiter) {
             if (nNewTickets >= chainparams.GetConsensus().nMaxFreshStakePerBlock) //new ticket purchases not more than max allowed in block
                 break;
+
+            auto stakedAmount = tickettxiter->GetSharedTx()->vout[ticketStakeOutputIndex].nValue;
+
+            // do not allow tickets with staked amounts lower than the block's stake difficulty
+            if (stakedAmount < pblock->nStakeDifficulty)
+                continue;
+
+            // do not allow tickets with staked amounts lower than the minimum stake difficulty
+            if (stakedAmount < chainparams.GetConsensus().nMinimumStakeDiff)
+                continue;
+
             // tx must be included in the block
             auto txiter = mempool.mapTx.project<0>(tickettxiter);
             AddToBlock(txiter);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -332,15 +332,14 @@ public:
 
     CAmount GetContributedAmount(const CTxMemPoolEntry& a) const
     {
-        auto contribAmount = CAmount(0);
-        TicketContribData contribData;
-        if (!ParseTicketContrib(a.GetTx(), ticketContribOutputIndex, contribData))
-        {
-            assert(!"not a vote transaction");
-        }
-        contribAmount = contribData.contributedAmount;
+        std::vector<TicketContribData> contributions;
+        CAmount totalContribution{0}, totalVoteFeeLimit{0}, totalRevocationFeeLimit{0};
 
-        return contribAmount;
+        if (!ParseTicketContribs(a.GetTx(), contributions, totalContribution, totalVoteFeeLimit, totalRevocationFeeLimit)) {
+            assert(!"not a ticket transaction");
+        }
+
+        return totalContribution;
     }
 };
 


### PR DESCRIPTION
This PR contains the following changes:

- updated the ordering of mempool ticket transactions to use the total ticket contribution;
- added filtration of tickets with low stake difficulty in block template assembler.