### PR TITLE
Implemented ticket transaction expiration

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -393,6 +393,10 @@ Wallet options:
 
   -tbvotingaccount
        Specify the account to be used for voting.
+       
+  -tbtxexpiry
+       Specifies the height after which the ticket transaction still in the mempool
+       is expired and can be removed from the mempool.
 
   -autovote
        Enable the automatic voter. This is going to send the votes for the tickets

--- a/src/help.txt
+++ b/src/help.txt
@@ -300,6 +300,10 @@ Wallet options:
   -tbvotingaccount
        Specify the account to be used for voting.
 
+  -tbtxexpiry
+       Specifies the height after which the ticket transaction still in the mempool
+       is expired and can be removed from the mempool.
+
   -autovote
        Enable the automatic voter. This is going to send the votes for the tickets
        belonging to the wallet as soon as they are selected as winners.

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -197,6 +197,11 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         for (auto tickettxiter = existingTickets.first; tickettxiter != existingTickets.second; ++tickettxiter) {
             if (nNewTickets >= chainparams.GetConsensus().nMaxFreshStakePerBlock) //new ticket purchases not more than max allowed in block
                 break;
+
+            // do not include ticket transactions that are expired
+            if (IsExpiredTx(tickettxiter->GetTx(), nHeight))
+                continue;
+
             // tx must be included in the block
             auto txiter = mempool.mapTx.project<0>(tickettxiter);
             AddToBlock(txiter);

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -180,6 +180,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     { "setticketbuyerbalancetomaintain", 0, "maintain" },
     { "setticketbuyerpoolfees", 0, "poolfees" },
     { "setticketbuyermaxperblock", 0, "limit" },
+    { "setticketbuyerexpiry", 0, "expiry" },
     { "generatevote", 1, "height" },
     { "generatevote", 3, "votebits" },
     { "startautovoter", 0, "votebits" },

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -612,7 +612,7 @@ void CTxMemPool::removeExpiredTickets(const int currentHeight, const Consensus::
 
     CTxMemPool::setEntries txToRemove;
     for (auto tickettxiter = tickets.first; tickettxiter != tickets.second; ++tickettxiter) {
-        if (IsExpiredTx(tickettxiter->GetTx(), currentHeight)) {
+        if (IsExpiredTx(tickettxiter->GetTx(), currentHeight + 1)) {
             auto txiter = mapTx.project<0>(tickettxiter);
 
             txToRemove.insert(txiter);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -597,7 +597,34 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef>& vtx, unsigne
     blockSinceLastRollingFeeBump = true;
 }
 
-void CTxMemPool::removeExpiredVotes(const uint32_t currentHeight, const Consensus::Params& params)
+void CTxMemPool::removeExpiredTickets(const int currentHeight, const Consensus::Params& params)
+{
+    // When a ticket transaction is expired, it is remmoved from the mempool.
+
+    if (!IsHybridConsensusForkEnabled(currentHeight, params))
+        return;
+
+    LOCK(cs);
+
+    // get the tickets
+    auto& tx_class_index = mapTx.get<tx_class>();
+    auto tickets = tx_class_index.equal_range(ETxClass::TX_BuyTicket);
+
+    CTxMemPool::setEntries txToRemove;
+    for (auto tickettxiter = tickets.first; tickettxiter != tickets.second; ++tickettxiter) {
+        if (IsExpiredTx(tickettxiter->GetTx(), currentHeight)) {
+            auto txiter = mapTx.project<0>(tickettxiter);
+
+            txToRemove.insert(txiter);
+
+            CalculateDescendants(txiter, txToRemove);
+        }
+    }
+
+    RemoveStaged(txToRemove, true, MemPoolRemovalReason::EXPIRY);
+}
+
+void CTxMemPool::removeExpiredVotes(const int currentHeight, const Consensus::Params& params)
 {
     // When a vote is lingering in the mempool for longer that the specified delay,
     // it is removed as it cannot be useful anymore. All its mempool descendants are
@@ -607,20 +634,21 @@ void CTxMemPool::removeExpiredVotes(const uint32_t currentHeight, const Consensu
         return;
 
     LOCK(cs);
+
     // get the votes
     auto& tx_class_index = mapTx.get<tx_class>();
     auto votes = tx_class_index.equal_range(ETxClass::TX_Vote);
 
     CTxMemPool::setEntries txToRemove;
     for (auto votetxiter = votes.first; votetxiter != votes.second; ++votetxiter) {
-        if (!IsHybridConsensusForkEnabled(votetxiter->GetHeight(), params))
+        if (!IsHybridConsensusForkEnabled(static_cast<int>(votetxiter->GetHeight()), params))
             continue;
 
         VoteData voteData;
         if (!ParseVote(votetxiter->GetTx(), voteData))
             continue;
 
-        if (voteData.blockHeight < currentHeight - params.nMempoolVoteExpiry) {
+        if (voteData.blockHeight < static_cast<unsigned int>(currentHeight) - params.nMempoolVoteExpiry) {
             auto txiter = mapTx.project<0>(votetxiter);
 
             txToRemove.insert(txiter);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -625,7 +625,8 @@ public:
     void removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags);
     void removeConflicts(const CTransaction &tx);
     void removeForBlock(const std::vector<CTransactionRef>& vtx, unsigned int nBlockHeight);
-    void removeExpiredVotes(const uint32_t currentHeight, const Consensus::Params& params);
+    void removeExpiredTickets(const int currentHeight, const Consensus::Params& params);
+    void removeExpiredVotes(const int currentHeight, const Consensus::Params& params);
 
     void clear();
     void _clear(); //lock free

--- a/src/wallet/init.cpp
+++ b/src/wallet/init.cpp
@@ -49,6 +49,7 @@ std::string GetWalletHelpString(bool showDebug)
     strUsage += HelpMessageOpt("-tbrewardaddress", strprintf(_("Specify the address to be used when sending the reward. The voter or revoker will send the reward or refund to this address.")));
     strUsage += HelpMessageOpt("-tblimit", strprintf(_("The maximum number of tickets to purchase in one batch.")));
     strUsage += HelpMessageOpt("-tbvotingaccount", strprintf(_("Specify the account to be used for voting.")));
+    strUsage += HelpMessageOpt("-tbtxexpiry", strprintf(_("Specifies the height after which the ticket transaction still in the mempool is expired and can be removed from the mempool.")));
     strUsage += HelpMessageOpt("-autovote", strprintf(_("Enable the automatic voter. This is going to send the votes for the tickets belonging to the wallet as soon as they are selected as winners. (default: %u)"), DEFAULT_AUTO_VOTE));
     strUsage += HelpMessageOpt("-autorevoke", strprintf(_("Enable the automatic revoker. As soon as a ticket becomes expired or missed, the automatic revoker creates and publishes a transaction that is unlocking the staked funds. (default: %u)"), DEFAULT_AUTO_REVOKE));
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3459,6 +3459,7 @@ UniValue startticketbuyer(const JSONRPCRequest& request)
             "7.  \"poolfeeaddress\"   (string, optional)   The address to pay stake pool fees to\n"
             "8.  poolfees             (numeric, optional)  The amount of fees to pay to the stake pool\n"
             "9.  limit                (numeric, optional)  Limit maximum number of purchased tickets per block\n"
+            "10. expiry               (numeric, optional)  The number of blocks after which the ticket transaction will be removed from mempool\n"
             "\nExamples:\n"
             "\nStart the ticket buyer from your default account to purchase tickets and leaving at least 50 PAI\n"
             + HelpExampleCli("startticketbuyer", "\"default\" 50")
@@ -3543,6 +3544,17 @@ UniValue startticketbuyer(const JSONRPCRequest& request)
             throw JSONRPCError(RPCErrorCode::INVALID_PARAMETER, "The number of tickets must be at least 1.");
     }
 
+    // Expiry
+    int expiry{0};
+    if (!request.params[9].isNull()) {
+        if (!request.params[9].isNum())
+            throw JSONRPCError(RPCErrorCode::INVALID_PARAMETER, "Invalid expiry.");
+
+        expiry = request.params[9].get_int();
+        if ((expiry < DEFAULT_TICKET_BUYER_TX_EXPIRY_MIN) || (expiry > DEFAULT_TICKET_BUYER_TX_EXPIRY_MAX))
+            throw JSONRPCError(RPCErrorCode::INVALID_PARAMETER, "The expiration interval must be within the limits.");
+    }
+
     CTicketBuyer *tb = pwallet->GetTicketBuyer();
     if (tb == nullptr)
         throw JSONRPCError(RPCErrorCode::INTERNAL_ERROR, "Ticket buyer not found.");
@@ -3557,6 +3569,7 @@ UniValue startticketbuyer(const JSONRPCRequest& request)
     cfg.poolFeeAddress = poolFeeAddress;
     cfg.poolFees = poolFees;
     cfg.limit = limit;
+    cfg.txExpiry = expiry;
 
     tb->start();
 
@@ -3614,6 +3627,7 @@ UniValue ticketbuyerconfig(const JSONRPCRequest& request)
             "  \"poolfees\" : x.xxx,                     (numeric) amount of fees to pay to the stake pool\n"
             "  \"limit\" : n,                            (numeric) maximum number of purchased tickets per block\n"
             "  \"minConf\" : n,                          (numeric) minimum number of block confirmations required\n"
+            "  \"expiry\" : n,                           (numeric) number of blocks after which the ticket transaction will be removed from mempool\n"
             "  }\n"
             "\nExample:\n"
             + HelpExampleCli("ticketbuyerconfig", "")
@@ -3640,6 +3654,7 @@ UniValue ticketbuyerconfig(const JSONRPCRequest& request)
     result.push_back(Pair("poolFees", cfg.poolFees));
     result.push_back(Pair("limit", cfg.limit));
     result.push_back(Pair("minConf", cfg.minConf));
+    result.push_back(Pair("expiry", cfg.txExpiry));
 
     return result;
 }
@@ -3905,6 +3920,42 @@ UniValue setticketbuyermaxperblock(const JSONRPCRequest& request)
     CTicketBuyerConfig& cfg = tb->GetConfig();
 
     cfg.limit = value;
+
+    return NullUniValue;
+}
+
+UniValue setticketbuyerexpiry(const JSONRPCRequest& request)
+{
+    const auto pwallet = GetWalletForJSONRPCRequest(request);
+    if (!EnsureWalletIsAvailable(pwallet, request.fHelp)) {
+        return NullUniValue;
+    }
+
+    if (request.fHelp || request.params.size() != 1)
+        throw std::runtime_error{
+            "setticketbuyerexpiry expiry\n"
+            "\nConfigure the number of blocks after which the ticket transaction will be removed from mempool.\n"
+            "\nArguments:\n"
+            "1.  expiry  (numeric, required)  The number of blocks after which the ticket transaction will be removed from mempool\n"
+            "\nExample:\n"
+            + HelpExampleCli("setticketbuyerexpiry", "100")
+            + HelpExampleRpc("setticketbuyerexpiry", "144")
+        };
+
+    ObserveSafeMode();
+    LOCK2(cs_main, pwallet->cs_wallet);
+
+    int value = request.params[0].get_int();
+    if ((value < DEFAULT_TICKET_BUYER_TX_EXPIRY_MIN) || (value > DEFAULT_TICKET_BUYER_TX_EXPIRY_MAX))
+        throw JSONRPCError(RPCErrorCode::INVALID_PARAMETER, "The expiration interval must be within the limits.");
+
+    CTicketBuyer *tb = pwallet->GetTicketBuyer();
+    if (tb == nullptr)
+        throw JSONRPCError(RPCErrorCode::INTERNAL_ERROR, "Ticket buyer not found.");
+
+    CTicketBuyerConfig& cfg = tb->GetConfig();
+
+    cfg.txExpiry = value;
 
     return NullUniValue;
 }
@@ -5444,6 +5495,7 @@ static const CRPCCommand commands[] =
     { "wallet",             "setticketbuyerpooladdress",        &setticketbuyerpooladdress,         {"pooladdress"} },
     { "wallet",             "setticketbuyerpoolfees",           &setticketbuyerpoolfees,            {"poolfees"} },
     { "wallet",             "setticketbuyermaxperblock",        &setticketbuyermaxperblock,         {"limit"} },
+    { "wallet",             "setticketbuyerexpiry",             &setticketbuyerexpiry,              {"expiry"} },
     { "wallet",             "generatevote",                     &generatevote,                      {"blockhash","height","tickethash","votebits","votebitsext"} },
     { "wallet",             "startautovoter",                   &startautovoter,                    {"votebits","votebitsext","passphrase"} },
     { "wallet",             "stopautovoter",                    &stopautovoter,                     {} },

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3410,12 +3410,12 @@ UniValue purchaseticket(const JSONRPCRequest& request)
 
     double dfPoolFee{0.0};
     if (!request.params[7].isNull())
-        dfPoolFee = request.params[6].get_real();
+        dfPoolFee = request.params[7].get_real();
 
     // Expiry
     int nExpiry{0};
     if (!request.params[8].isNull())
-        nExpiry = request.params[7].get_int();
+        nExpiry = request.params[8].get_int();
 
     // Ticket Fee
     CAmount ticketFeeIncrement{0};

--- a/src/wallet/test/ticket_tests.cpp
+++ b/src/wallet/test/ticket_tests.cpp
@@ -1316,6 +1316,9 @@ BOOST_FIXTURE_TEST_CASE(ticket_buyer_rpc, WalletStakeTestingSetup)
     BOOST_CHECK_THROW(CallRpc("setticketbuyermaxperblock"), std::runtime_error);
     BOOST_CHECK_NO_THROW(CallRpc("setticketbuyermaxperblock 5"));
 
+    BOOST_CHECK_THROW(CallRpc("setticketbuyerexpiry"), std::runtime_error);
+    BOOST_CHECK_NO_THROW(CallRpc("setticketbuyerexpiry 100"));
+
     BOOST_CHECK_EQUAL(cfg.buyTickets, false);
     BOOST_CHECK_EQUAL(cfg.account, "abc");
     BOOST_CHECK_EQUAL(cfg.maintain, 12300000000);
@@ -1324,6 +1327,7 @@ BOOST_FIXTURE_TEST_CASE(ticket_buyer_rpc, WalletStakeTestingSetup)
     BOOST_CHECK(cfg.poolFeeAddress == vspKeyId);
     BOOST_CHECK_EQUAL(cfg.poolFees, 5.0);
     BOOST_CHECK_EQUAL(cfg.limit, 5);
+    BOOST_CHECK_EQUAL(cfg.txExpiry, 100);
 
     // Settings (read)
 
@@ -1339,6 +1343,7 @@ BOOST_FIXTURE_TEST_CASE(ticket_buyer_rpc, WalletStakeTestingSetup)
     BOOST_CHECK_EQUAL(find_value(r.get_obj(), "poolFees").get_real(), 5.0);
     BOOST_CHECK_EQUAL(find_value(r.get_obj(), "limit").get_int(), 5);
     BOOST_CHECK_EQUAL(find_value(r.get_obj(), "minConf").get_int(), 1);
+    BOOST_CHECK_EQUAL(find_value(r.get_obj(), "expiry").get_int(), 100);
 
     // Start (with minimal settings)
 
@@ -1354,6 +1359,7 @@ BOOST_FIXTURE_TEST_CASE(ticket_buyer_rpc, WalletStakeTestingSetup)
     BOOST_CHECK(cfg.poolFeeAddress.which() == 0);
     BOOST_CHECK_EQUAL(cfg.poolFees, 0.0);
     BOOST_CHECK_EQUAL(cfg.limit, 1);
+    BOOST_CHECK_EQUAL(cfg.limit, 100);
 
     // Start (with full settings)
 
@@ -1361,7 +1367,7 @@ BOOST_FIXTURE_TEST_CASE(ticket_buyer_rpc, WalletStakeTestingSetup)
 
     BOOST_CHECK_EQUAL(cfg.buyTickets, false);
 
-    BOOST_CHECK_NO_THROW(CallRpc(std::string("startticketbuyer fromaccount 125 \"\" votingaccount ") + ticketAddress + " " + rewardAddress + " " + vspAddress + " 10.0 8"));
+    BOOST_CHECK_NO_THROW(CallRpc(std::string("startticketbuyer fromaccount 125 \"\" votingaccount ") + ticketAddress + " " + rewardAddress + " " + vspAddress + " 10.0 8 120"));
 
     BOOST_CHECK_EQUAL(cfg.buyTickets, true);
     BOOST_CHECK_EQUAL(cfg.account, "fromaccount");
@@ -1371,6 +1377,7 @@ BOOST_FIXTURE_TEST_CASE(ticket_buyer_rpc, WalletStakeTestingSetup)
     BOOST_CHECK(cfg.poolFeeAddress == vspKeyId);
     BOOST_CHECK_EQUAL(cfg.poolFees, 10.0);
     BOOST_CHECK_EQUAL(cfg.limit, 8);
+    BOOST_CHECK_EQUAL(cfg.txExpiry, 120);
 
     // Stop
 
@@ -1389,9 +1396,9 @@ BOOST_FIXTURE_TEST_CASE(ticket_buyer_rpc, WalletStakeTestingSetup)
 
     BOOST_CHECK_THROW(CallRpc("startticketbuyer def 124"), std::runtime_error);
     BOOST_CHECK_THROW(CallRpc("startticketbuyer def 124 wrongP4ssword!"), std::runtime_error);
-    BOOST_CHECK_THROW(CallRpc("startticketbuyer def 124 wrongP4ssword votingaccount " + ticketAddress + " " + rewardAddress + " " + vspAddress + " 10.0 8"), std::runtime_error);
+    BOOST_CHECK_THROW(CallRpc("startticketbuyer def 124 wrongP4ssword votingaccount " + ticketAddress + " " + rewardAddress + " " + vspAddress + " 10.0 8 120"), std::runtime_error);
 
-    BOOST_CHECK_NO_THROW(CallRpc(std::string("startticketbuyer fromaccount 125 ") + std::string(passphrase.c_str()) + " votingaccount " + ticketAddress + " " + rewardAddress + " " + vspAddress + " 10.0 8"));
+    BOOST_CHECK_NO_THROW(CallRpc(std::string("startticketbuyer fromaccount 125 ") + std::string(passphrase.c_str()) + " votingaccount " + ticketAddress + " " + rewardAddress + " " + vspAddress + " 10.0 8 120"));
 
     BOOST_CHECK_EQUAL(cfg.buyTickets, true);
     BOOST_CHECK_EQUAL(cfg.account, "fromaccount");
@@ -1401,6 +1408,7 @@ BOOST_FIXTURE_TEST_CASE(ticket_buyer_rpc, WalletStakeTestingSetup)
     BOOST_CHECK(cfg.poolFeeAddress == vspKeyId);
     BOOST_CHECK_EQUAL(cfg.poolFees, 10.0);
     BOOST_CHECK_EQUAL(cfg.limit, 8);
+    BOOST_CHECK_EQUAL(cfg.txExpiry, 120);
     BOOST_CHECK_EQUAL(cfg.passphrase, passphrase);
 
     tb->stop();

--- a/src/wallet/ticket-buyer/ticketbuyer.cpp
+++ b/src/wallet/ticket-buyer/ticketbuyer.cpp
@@ -141,7 +141,7 @@ void CTicketBuyer::mainLoop()
             }
 
             // Set expiry to prevent tickets from being mined in the next
-            // sdiff interval.  When the next block begins the new interval,
+            // sdiff interval. When the next block begins the new interval,
             // the ticket is being purchased for the next interval; therefore
             // increment expiry by a full sdiff window size to prevent it
             // being mined in the interval after the next.
@@ -149,6 +149,11 @@ void CTicketBuyer::mainLoop()
             if (height + 1 == nextIntervalStart) {
                 expiry += intervalSize;
             }
+
+            // Make sure to use the specified value if that is within the limits
+            // of the stake difficulty window.
+            if (height + config.txExpiry < expiry)
+                expiry = height + config.txExpiry;
         }
 
         // TODO check rescan point

--- a/src/wallet/ticket-buyer/ticketbuyerconfig.cpp
+++ b/src/wallet/ticket-buyer/ticketbuyerconfig.cpp
@@ -15,7 +15,8 @@ CTicketBuyerConfig::CTicketBuyerConfig() :
     rewardAddress(CNoDestination()),
     poolFeeAddress(CNoDestination()),
     poolFees(0.0),
-    limit(1)
+    limit(1),
+    txExpiry(DEFAULT_TICKET_BUYER_TX_EXPIRY)
 {
 }
 

--- a/src/wallet/ticket-buyer/ticketbuyerconfig.cpp
+++ b/src/wallet/ticket-buyer/ticketbuyerconfig.cpp
@@ -39,4 +39,14 @@ void CTicketBuyerConfig::ParseCommandline()
 
     if (gArgs.IsArgSet("-tbvotingaccount"))
         votingAccount = gArgs.GetArg("-tbvotingaccount", "");
+
+    if (gArgs.IsArgSet("-tbtxexpiry")) {
+        auto expiry = gArgs.GetArg("-tbtxexpiry", txExpiry);
+        if (expiry < DEFAULT_TICKET_BUYER_TX_EXPIRY_MIN)
+            txExpiry = DEFAULT_TICKET_BUYER_TX_EXPIRY_MIN;
+        else if (expiry > DEFAULT_TICKET_BUYER_TX_EXPIRY_MAX)
+            txExpiry = DEFAULT_TICKET_BUYER_TX_EXPIRY_MAX;
+        else
+            txExpiry = static_cast<int>(expiry);
+    }
 }

--- a/src/wallet/ticket-buyer/ticketbuyerconfig.h
+++ b/src/wallet/ticket-buyer/ticketbuyerconfig.h
@@ -11,6 +11,10 @@
 #include "support/allocators/secure.h"
 #include "key_io.h"
 
+#define DEFAULT_TICKET_BUYER_TX_EXPIRY 144
+#define DEFAULT_TICKET_BUYER_TX_EXPIRY_MIN 10
+#define DEFAULT_TICKET_BUYER_TX_EXPIRY_MAX 1000
+
 // The ticket buyer (TB) configuration
 class CTicketBuyerConfig {
 
@@ -47,6 +51,9 @@ public:
 
     // Wallet passphrase
     SecureString passphrase;
+
+    // Ticket expiry
+    int txExpiry = DEFAULT_TICKET_BUYER_TX_EXPIRY;
 
     CTicketBuyerConfig();
 

--- a/src/wallet/ticket-buyer/ticketbuyerconfig.h
+++ b/src/wallet/ticket-buyer/ticketbuyerconfig.h
@@ -53,7 +53,7 @@ public:
     SecureString passphrase;
 
     // Ticket expiry
-    int txExpiry = DEFAULT_TICKET_BUYER_TX_EXPIRY;
+    int txExpiry;
 
     CTicketBuyerConfig();
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1912,6 +1912,8 @@ std::pair<std::vector<std::string>, CWalletError> CWallet::PurchaseTicket(std::s
 
         CMutableTransaction mTicketTx;
 
+        mTicketTx.nExpiry = expiry;
+
         // inputs
 
         if (useVsp) {


### PR DESCRIPTION
This PR implements the transaction based expiration for tickets.
If a ticket transaction is expired, then it is removed from the mempool and not included in the block template.