### PR TITLE
Added expiry awareness to stake transactions size calculations

### DIFF
--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -185,6 +185,7 @@ struct CMutableTransaction;
  * - std::vector<CTxIn> vin
  * - std::vector<CTxOut> vout
  * - uint32_t nLockTime
+ * - uint32_t nExpiry (if nVersion >= 3)
  *
  * Extended transaction serialization format:
  * - int32_t nVersion
@@ -195,6 +196,7 @@ struct CMutableTransaction;
  * - if (flags & 1):
  *   - CTxWitness wit;
  * - uint32_t nLockTime
+ * - uint32_t nExpiry (if nVersion >= 3)
  */
 template<typename Stream, typename TxType>
 inline void UnserializeTransaction(TxType& tx, Stream& s) {
@@ -229,11 +231,10 @@ inline void UnserializeTransaction(TxType& tx, Stream& s) {
         throw std::ios_base::failure("Unknown transaction optional data");
     }
     s >> tx.nLockTime;
-    // if (tx.nVersion > 4) {
-    //     s >> tx.nExpiry;
-    // } else {
+    if (tx.nVersion >= 3)
+        s >> tx.nExpiry;
+    else
         tx.nExpiry = 0;
-    // }
 }
 
 template<typename Stream, typename TxType>
@@ -263,9 +264,8 @@ inline void SerializeTransaction(const TxType& tx, Stream& s) {
         }
     }
     s << tx.nLockTime;
-    // if (tx.nVersion > 4) {
-    //     s << tx.nExpiry;
-    // }
+    if (tx.nVersion >= 3)
+        s << tx.nExpiry;
 }
 
 
@@ -276,13 +276,13 @@ class CTransaction
 {
 public:
     // Default transaction version.
-    static const int32_t CURRENT_VERSION=2;
+    static const int32_t CURRENT_VERSION=3;
 
     // Changing the default transaction version requires a two step process: first
     // adapting relay policy by bumping MAX_STANDARD_VERSION, and then later date
     // bumping the default CURRENT_VERSION at which point both CURRENT_VERSION and
     // MAX_STANDARD_VERSION will be equal.
-    static const int32_t MAX_STANDARD_VERSION=2;
+    static const int32_t MAX_STANDARD_VERSION=3;
 
     // The local variables are made const to prevent unintended modification
     // without updating the cached hash value. However, CTransaction is not

--- a/src/stake/staketx.cpp
+++ b/src/stake/staketx.cpp
@@ -560,12 +560,12 @@ size_t GetEstimatedTicketContribTxOutSize()
     return GetSerializeSize(txOut, SER_NETWORK, PROTOCOL_VERSION);
 }
 
-size_t GetEstimatedSizeOfBuyTicketTx(bool useVsp)
+size_t GetEstimatedSizeOfBuyTicketTx(bool useVsp, bool includeExpiry)
 {
     // since the format of the ticket purchase transaction is fixed,
     // its size can be estimated precisely.
     // A ticket purchase transaction has the structure described in ValidateBuyTicketStructure().
-    // version + in count (1|2) + (1|2) regular input + out count (4|5) + buy ticket decl output + ticket address output + pool fee contributor (optional)  + pool fee change output (optional) + contributor info output + change output + locktime
+    // version + in count (1|2) + (1|2) regular input + out count (4|5) + buy ticket decl output + ticket address output + pool fee contributor (optional)  + pool fee change output (optional) + contributor info output + change output + locktime + expiry (optional)
 
     return 4
             + 1
@@ -578,7 +578,8 @@ size_t GetEstimatedSizeOfBuyTicketTx(bool useVsp)
             + (useVsp ? GetEstimatedP2PKHTxOutSize() : 0)
             + GetEstimatedTicketContribTxOutSize()
             + GetEstimatedP2PKHTxOutSize()
-            + 4;
+            + 4
+            + (includeExpiry ? 4 : 0);
 }
 
 size_t GetEstimatedRevokeTicketDeclTxOutSize()
@@ -588,12 +589,12 @@ size_t GetEstimatedRevokeTicketDeclTxOutSize()
     return GetSerializeSize(txOut, SER_NETWORK, PROTOCOL_VERSION);
 }
 
-size_t GetEstimatedSizeOfRevokeTicketTx(const size_t refundsCount, bool compressedInput)
+size_t GetEstimatedSizeOfRevokeTicketTx(const size_t refundsCount, bool compressedInput, bool includeExpiry)
 {
     // since the format of the revocation transaction is fixed,
     // its size can be estimated precisely.
     // A revocation transaction has the structure described in ValidateRevokeTicketStructure().
-    // version + in count 1 + 1 regular input + out count (1+n) + revoke ticket decl output + n regular outputs + locktime
+    // version + in count 1 + 1 regular input + out count (1+n) + revoke ticket decl output + n regular outputs + locktime + expiry (optional)
 
     return 4
             + 1
@@ -601,7 +602,8 @@ size_t GetEstimatedSizeOfRevokeTicketTx(const size_t refundsCount, bool compress
             + 2
             + GetEstimatedRevokeTicketDeclTxOutSize()
             + refundsCount * GetEstimatedP2PKHTxOutSize()
-            + 4;
+            + 4
+            + (includeExpiry ? 4 : 0);
 }
 
 StakeSlice::StakeSlice(std::vector<CTransactionRef> vtx)

--- a/src/stake/staketx.h
+++ b/src/stake/staketx.h
@@ -214,10 +214,10 @@ size_t GetEstimatedP2PKHTxOutSize();
 
 size_t GetEstimatedBuyTicketDeclTxOutSize();
 size_t GetEstimatedTicketContribTxOutSize();
-size_t GetEstimatedSizeOfBuyTicketTx(bool useVsp);
+size_t GetEstimatedSizeOfBuyTicketTx(bool useVsp, bool includeExpiry = true);
 
 size_t GetEstimatedRevokeTicketDeclTxOutSize();
-size_t GetEstimatedSizeOfRevokeTicketTx(const size_t refundsCount, bool compressedInput = true);
+size_t GetEstimatedSizeOfRevokeTicketTx(const size_t refundsCount, bool compressedInput = true, bool includeExpiry = true);
 
 // ==============================
 

--- a/src/wallet/test/revoke_tests.cpp
+++ b/src/wallet/test/revoke_tests.cpp
@@ -19,12 +19,14 @@ BOOST_AUTO_TEST_CASE(revoke_estimated_sizes)
 {
     BOOST_CHECK_EQUAL(GetEstimatedRevokeTicketDeclTxOutSize(), 16U);
 
-    BOOST_CHECK_EQUAL(GetEstimatedSizeOfRevokeTicketTx(0), 175U);
-    BOOST_CHECK_EQUAL(GetEstimatedSizeOfRevokeTicketTx(0, false), 207U);
+    BOOST_CHECK_EQUAL(GetEstimatedSizeOfRevokeTicketTx(0), 179U);
+    BOOST_CHECK_EQUAL(GetEstimatedSizeOfRevokeTicketTx(0, false), 211U);
+    BOOST_CHECK_EQUAL(GetEstimatedSizeOfRevokeTicketTx(0, false, false), 207U);
+    BOOST_CHECK_EQUAL(GetEstimatedSizeOfRevokeTicketTx(0, true, false), 175U);
 
-    BOOST_CHECK_EQUAL(GetEstimatedSizeOfRevokeTicketTx(1), 209U);
-    BOOST_CHECK_EQUAL(GetEstimatedSizeOfRevokeTicketTx(2), 243U);
-    BOOST_CHECK_EQUAL(GetEstimatedSizeOfRevokeTicketTx(10), 515U);
+    BOOST_CHECK_EQUAL(GetEstimatedSizeOfRevokeTicketTx(1), 213U);
+    BOOST_CHECK_EQUAL(GetEstimatedSizeOfRevokeTicketTx(2), 247U);
+    BOOST_CHECK_EQUAL(GetEstimatedSizeOfRevokeTicketTx(10), 519U);
 }
 
 // test the calculation of gross and net remunerations

--- a/src/wallet/test/ticket_tests.cpp
+++ b/src/wallet/test/ticket_tests.cpp
@@ -490,8 +490,10 @@ BOOST_AUTO_TEST_CASE(ticket_purchase_estimated_sizes)
 
     BOOST_CHECK_EQUAL(GetEstimatedTicketContribTxOutSize(), 64U);
 
-    BOOST_CHECK_EQUAL(GetEstimatedSizeOfBuyTicketTx(true), 552U);
-    BOOST_CHECK_EQUAL(GetEstimatedSizeOfBuyTicketTx(false), 306U);
+    BOOST_CHECK_EQUAL(GetEstimatedSizeOfBuyTicketTx(true), 556U);
+    BOOST_CHECK_EQUAL(GetEstimatedSizeOfBuyTicketTx(false), 310U);
+    BOOST_CHECK_EQUAL(GetEstimatedSizeOfBuyTicketTx(true, false), 552U);
+    BOOST_CHECK_EQUAL(GetEstimatedSizeOfBuyTicketTx(false, false), 306U);
 }
 
 // test the ticket ownership verification

--- a/src/wallet/test/wallet_stake_test_fixture.cpp
+++ b/src/wallet/test/wallet_stake_test_fixture.cpp
@@ -563,7 +563,7 @@ CMutableTransaction WalletStakeTestingSetup::CreateTicketTx(const CAmount stakeD
 
 bool WalletStakeTestingSetup::AddToMempoolUnchecked(const CMutableTransaction& mtx) {
     LockPoints lp;
-    mempool.addUnchecked(mtx.GetHash(), CTxMemPoolEntry(MakeTransactionRef(mtx), 10000, 0, 1, false, false, 4, lp));
+    return mempool.addUnchecked(mtx.GetHash(), CTxMemPoolEntry(MakeTransactionRef(mtx), 0, 0, 1, false, false, 4, lp));
 }
 
 bool WalletStakeTestingSetup::MempoolHasTicket() {


### PR DESCRIPTION
This PR adds the expiry field to the stake transactions size calculations and also updates the corresponding unit tests.
It should be merged after https://github.com/projectpai/paicoin/pull/366.