### PR TITLE
Updated balance calculations not to include staked amounts

### DIFF
--- a/src/stake/staketx.cpp
+++ b/src/stake/staketx.cpp
@@ -199,14 +199,13 @@ bool IsStakeTx(const CTransaction& tx)
     return IsStakeTx(ParseTxClass(tx));
 }
 
-bool IsStakeTxOutSpendableByRegularTx(const CTransaction& tx, const uint32_t txoutIndex)
+bool IsStakeTxOutSpendableByRegularTx(ETxClass txClass, const uint32_t txoutIndex)
 {
     // the stake transaction outputs that can be spent directly by a regular transaction are:
     // - ticket purchase: any change output (but not the stake output)
     // - vote: any reward output
     // - revocation: any refund output
 
-    ETxClass txClass = ParseTxClass(tx);
     switch (txClass) {
         case TX_Regular:
             return true;
@@ -222,6 +221,11 @@ bool IsStakeTxOutSpendableByRegularTx(const CTransaction& tx, const uint32_t txo
     }
 
     return false;
+}
+
+bool IsStakeTxOutSpendableByRegularTx(const CTransaction& tx, const uint32_t txoutIndex)
+{
+    return IsStakeTxOutSpendableByRegularTx(ParseTxClass(tx), txoutIndex);
 }
 
 bool HasStakebaseContents(const CTxIn& txIn)

--- a/src/stake/staketx.h
+++ b/src/stake/staketx.h
@@ -200,6 +200,7 @@ bool ParseTicketContribs(const CTransaction& tx, std::vector<TicketContribData>&
 bool ParseVote(const CTransaction& tx, VoteData& data);
 bool IsStakeTx(ETxClass txClass);
 bool IsStakeTx(const CTransaction& tx);
+bool IsStakeTxOutSpendableByRegularTx(ETxClass txClass, const uint32_t txoutIndex);
 bool IsStakeTxOutSpendableByRegularTx(const CTransaction& tx, const uint32_t txoutIndex);
 bool HasStakebaseContents(const CTxIn& txIn);
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2823,6 +2823,7 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
             "  \"walletname\": xxxxx,             (string) the wallet name\n"
             "  \"walletversion\": xxxxx,          (numeric) the wallet version\n"
             "  \"balance\": xxxxxxx,              (numeric) the total confirmed balance of the wallet in " + CURRENCY_UNIT + "\n"
+            "  \"staked_balance\": xxxxxxx,       (numeric) the total staked balance of the wallet in " + CURRENCY_UNIT + "\n"
             "  \"unconfirmed_balance\": xxx,      (numeric) the total unconfirmed balance of the wallet in " + CURRENCY_UNIT + "\n"
             "  \"immature_balance\": xxxxxx,      (numeric) the total immature balance of the wallet in " + CURRENCY_UNIT + "\n"
             "  \"txcount\": xxxxxxx,              (numeric) the total number of transactions in the wallet\n"
@@ -2846,20 +2847,21 @@ UniValue getwalletinfo(const JSONRPCRequest& request)
     const auto kpExternalSize = pwallet->KeypoolCountExternalKeys();
     obj.push_back(Pair("walletname", pwallet->GetName()));
     obj.push_back(Pair("walletversion", pwallet->GetVersion()));
-    obj.push_back(Pair("balance",       ValueFromAmount(pwallet->GetBalance())));
+    obj.push_back(Pair("balance", ValueFromAmount(pwallet->GetBalance())));
+    obj.push_back(Pair("staked_balance", ValueFromAmount(pwallet->GetStakedBalance())));
     obj.push_back(Pair("unconfirmed_balance", ValueFromAmount(pwallet->GetUnconfirmedBalance())));
-    obj.push_back(Pair("immature_balance",    ValueFromAmount(pwallet->GetImmatureBalance())));
-    obj.push_back(Pair("txcount",       (int)pwallet->mapWallet.size()));
+    obj.push_back(Pair("immature_balance", ValueFromAmount(pwallet->GetImmatureBalance())));
+    obj.push_back(Pair("txcount", (int)pwallet->mapWallet.size()));
     obj.push_back(Pair("keypoololdest", pwallet->GetOldestKeyPoolTime()));
     obj.push_back(Pair("keypoolsize", static_cast<int64_t>(kpExternalSize)));
     const CKeyID masterKeyID{pwallet->GetHDChain().masterKeyID};
     if (!masterKeyID.IsNull() && pwallet->CanSupportFeature(FEATURE_HD_SPLIT)) {
-        obj.push_back(Pair("keypoolsize_hd_internal",   static_cast<int64_t>((pwallet->GetKeyPoolSize() - kpExternalSize))));
+        obj.push_back(Pair("keypoolsize_hd_internal", static_cast<int64_t>((pwallet->GetKeyPoolSize() - kpExternalSize))));
     }
     if (pwallet->IsCrypted()) {
         obj.push_back(Pair("unlocked_until", pwallet->nRelockTime));
     }
-    obj.push_back(Pair("paytxfee",      ValueFromAmount(payTxFee.GetFeePerK())));
+    obj.push_back(Pair("paytxfee", ValueFromAmount(payTxFee.GetFeePerK())));
     if (!masterKeyID.IsNull())
          obj.push_back(Pair("hdmasterkeyid", masterKeyID.GetHex()));
     return obj;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -26,6 +26,7 @@
 #include "wallet/auto-voter/autovoter.h"
 #include "wallet/auto-revoker/autorevoker.h"
 #include "wallet/ticket-buyer/ticketbuyer.h"
+#include "stake/staketx.h"
 
 #include <algorithm>
 #include <atomic>
@@ -337,6 +338,7 @@ public:
     // memory only
     mutable bool fDebitCached;
     mutable bool fCreditCached;
+    mutable bool fStakedCreditCached;
     mutable bool fImmatureCreditCached;
     mutable bool fAvailableCreditCached;
     mutable bool fWatchDebitCached;
@@ -346,6 +348,7 @@ public:
     mutable bool fChangeCached;
     mutable CAmount nDebitCached;
     mutable CAmount nCreditCached;
+    mutable CAmount nStakedCreditCached;
     mutable CAmount nImmatureCreditCached;
     mutable CAmount nAvailableCreditCached;
     mutable CAmount nWatchDebitCached;
@@ -376,6 +379,7 @@ public:
         strFromAccount.clear();
         fDebitCached = false;
         fCreditCached = false;
+        fStakedCreditCached = false;
         fImmatureCreditCached = false;
         fAvailableCreditCached = false;
         fWatchDebitCached = false;
@@ -385,6 +389,7 @@ public:
         fChangeCached = false;
         nDebitCached = 0;
         nCreditCached = 0;
+        nStakedCreditCached = 0;
         nImmatureCreditCached = 0;
         nAvailableCreditCached = 0;
         nWatchDebitCached = 0;
@@ -442,6 +447,7 @@ public:
     void MarkDirty()
     {
         fCreditCached = false;
+        fStakedCreditCached = false;
         fAvailableCreditCached = false;
         fImmatureCreditCached = false;
         fWatchDebitCached = false;
@@ -461,6 +467,7 @@ public:
     //! filter decides which addresses will count towards the debit
     CAmount GetDebit(const isminefilter& filter) const;
     CAmount GetCredit(const isminefilter& filter) const;
+    CAmount GetStakedCredit(bool fUseCache=true) const;
     CAmount GetImmatureCredit(bool fUseCache=true) const;
     CAmount GetAvailableCredit(bool fUseCache=true) const;
     CAmount GetImmatureWatchOnlyCredit(const bool& fUseCache=true) const;
@@ -1010,6 +1017,7 @@ public:
     // ResendWalletTransactionsBefore may only be called if fBroadcastTransactions!
     std::vector<uint256> ResendWalletTransactionsBefore(int64_t nTime, CConnman* connman);
     CAmount GetBalance() const;
+    CAmount GetStakedBalance() const;
     CAmount GetUnconfirmedBalance() const;
     CAmount GetImmatureBalance() const;
     CAmount GetWatchOnlyBalance() const;
@@ -1080,7 +1088,8 @@ public:
      */
     CAmount GetDebit(const CTxIn& txin, const isminefilter& filter) const;
     isminetype IsMine(const CTxOut& txout) const;
-    CAmount GetCredit(const CTxOut& txout, const isminefilter& filter) const;
+    CAmount GetCredit(const CTxOut& txOut, const isminefilter& filter) const;
+    CAmount GetCredit(const ETxClass txClass, const uint32_t txIndex, const CTxOut& txOut, const isminefilter& filter) const;
     bool IsChange(const CTxOut& txout) const;
     CAmount GetChange(const CTxOut& txout) const;
     bool IsMine(const CTransaction& tx) const;


### PR DESCRIPTION
The balance was calculated considering the stake output of a ticket as credit, which is not correct since that output can only be spent by a vote or revocation.
This PR updates the balance calculations not to consider the outputs that are not spendable by regular transactions.
Please note that this will result in a significant decrease of the balance shown to a user if he/she has staked funds.