### PR TITLE
Removed expired tickets from wallet and updated balance calculations

### DIFF
--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -228,7 +228,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
             //
             for (const CTxIn& txin : wtx.tx->vin)
                 if (wallet->IsMine(txin))
-                    strHTML += "<b>" + tr("Debit") + ":</b> " + PAIcoinUnits::formatHtmlWithUnit(unit, -wallet->GetDebit(txin, ISMINE_ALL)) + "<br>";
+                    strHTML += "<b>" + tr("Debit") + ":</b> " + PAIcoinUnits::formatHtmlWithUnit(unit, -wallet->GetDebit(txClass, txin, ISMINE_ALL)) + "<br>";
             for (uint32_t i = 0; i < wtx.tx->vout.size(); ++i) {
                 const CTxOut& txout = wtx.tx->vout[i];
                 if (wallet->IsMine(txout))
@@ -285,7 +285,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
         strHTML += "<hr><br>" + tr("Debug information") + "<br><br>";
         for (const CTxIn& txin : wtx.tx->vin)
             if(wallet->IsMine(txin))
-                strHTML += "<b>" + tr("Debit") + ":</b> " + PAIcoinUnits::formatHtmlWithUnit(unit, -wallet->GetDebit(txin, ISMINE_ALL)) + "<br>";
+                strHTML += "<b>" + tr("Debit") + ":</b> " + PAIcoinUnits::formatHtmlWithUnit(unit, -wallet->GetDebit(txClass, txin, ISMINE_ALL)) + "<br>";
         for (uint32_t i = 0; i < wtx.tx->vout.size(); ++i) {
             const CTxOut& txout = wtx.tx->vout[i];
             if (wallet->IsMine(txout))

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3077,6 +3077,11 @@ bool ActivateBestChain(CValidationState &state, const CChainParams& chainparams,
     if (fDiscardExpiredMempoolVotes)
         mempool.removeExpiredVotes(height, chainparams.GetConsensus());
 
+    // notify wallet and other interested listeners.
+    // This should go after the mempool cleanup above, since the wallet
+    // relies on mempool presence for cleanup.
+    GetMainSignals().CleanupTransactions(height);
+
     // Write changes periodically to disk, after relay.
     if (!FlushStateToDisk(chainparams, state, FLUSH_STATE_PERIODIC)) {
         return false;

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -24,6 +24,7 @@ struct MainSignalsInstance {
     boost::signals2::signal<void (int64_t nBestBlockTime, CConnman* connman)> Broadcast;
     boost::signals2::signal<void (const CBlock&, const CValidationState&)> BlockChecked;
     boost::signals2::signal<void (const CBlockIndex *, const std::shared_ptr<const CBlock>&)> NewPoWValidBlock;
+    boost::signals2::signal<void (const int)> CleanupTransactions;
 
     // We are not allowed to assume the scheduler only runs in one thread,
     // but must ensure all callbacks happen in-order, so we end up creating
@@ -63,6 +64,7 @@ void RegisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.m_internals->Broadcast.connect(boost::bind(&CValidationInterface::ResendWalletTransactions, pwalletIn, _1, _2));
     g_signals.m_internals->BlockChecked.connect(boost::bind(&CValidationInterface::BlockChecked, pwalletIn, _1, _2));
     g_signals.m_internals->NewPoWValidBlock.connect(boost::bind(&CValidationInterface::NewPoWValidBlock, pwalletIn, _1, _2));
+    g_signals.m_internals->CleanupTransactions.connect(boost::bind(&CValidationInterface::CleanupTransactions, pwalletIn, _1));
 }
 
 void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
@@ -75,6 +77,7 @@ void UnregisterValidationInterface(CValidationInterface* pwalletIn) {
     g_signals.m_internals->BlockDisconnected.disconnect(boost::bind(&CValidationInterface::BlockDisconnected, pwalletIn, _1));
     g_signals.m_internals->UpdatedBlockTip.disconnect(boost::bind(&CValidationInterface::UpdatedBlockTip, pwalletIn, _1, _2, _3));
     g_signals.m_internals->NewPoWValidBlock.disconnect(boost::bind(&CValidationInterface::NewPoWValidBlock, pwalletIn, _1, _2));
+    g_signals.m_internals->CleanupTransactions.disconnect(boost::bind(&CValidationInterface::CleanupTransactions, pwalletIn, _1));
 }
 
 void UnregisterAllValidationInterfaces() {
@@ -87,6 +90,7 @@ void UnregisterAllValidationInterfaces() {
     g_signals.m_internals->BlockDisconnected.disconnect_all_slots();
     g_signals.m_internals->UpdatedBlockTip.disconnect_all_slots();
     g_signals.m_internals->NewPoWValidBlock.disconnect_all_slots();
+    g_signals.m_internals->CleanupTransactions.disconnect_all_slots();
 }
 
 void CMainSignals::UpdatedBlockTip(const CBlockIndex *pindexNew, const CBlockIndex *pindexFork, bool fInitialDownload) {
@@ -123,4 +127,8 @@ void CMainSignals::BlockChecked(const CBlock& block, const CValidationState& sta
 
 void CMainSignals::NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock> &block) {
     m_internals->NewPoWValidBlock(pindex, block);
+}
+
+void CMainSignals::CleanupTransactions(const int height) {
+    m_internals->CleanupTransactions(height);
 }

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -60,6 +60,10 @@ protected:
      * Notifies listeners that a block which builds directly on our current tip
      * has been received and connected to the headers tree, though not validated yet */
     virtual void NewPoWValidBlock(const CBlockIndex *pindex, const std::shared_ptr<const CBlock>& block) {};
+    /**
+     * Notifies listeners that transactions can be purged if needed */
+    virtual void CleanupTransactions(const int height) {}
+
     friend void ::RegisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterValidationInterface(CValidationInterface*);
     friend void ::UnregisterAllValidationInterfaces();
@@ -91,6 +95,7 @@ public:
     void Broadcast(int64_t nBestBlockTime, CConnman* connman);
     void BlockChecked(const CBlock&, const CValidationState&);
     void NewPoWValidBlock(const CBlockIndex *, const std::shared_ptr<const CBlock>&);
+    void CleanupTransactions(const int height);
 };
 
 CMainSignals& GetMainSignals();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -743,6 +743,9 @@ private:
 
     void SyncMetaData(std::pair<TxSpends::iterator, TxSpends::iterator>);
 
+    /* Remove all the outpoints corresponding to the specified transactions from the spends list */
+    void RemoveFromSpends(const std::vector<uint256>& hashes);
+
     /* Used by TransactionAddedToMemorypool/BlockConnected/Disconnected.
      * Should be called with pindexBlock and posInBlock if this is for a transaction that is included in a block. */
     void SyncTransaction(const CTransactionRef& tx, const CBlockIndex *pindex = nullptr, int posInBlock = 0);
@@ -892,6 +895,8 @@ public:
     typedef std::multimap<int64_t, TxPair > TxItems;
     TxItems wtxOrdered;
 
+    void RemoveFromWtxOrdered(std::vector<uint256> hashes);
+
     int64_t nOrderPosNext;
     uint64_t nAccountingEntryNumber;
     std::map<uint256, int> mapRequestCount;
@@ -1017,7 +1022,7 @@ public:
     // ResendWalletTransactionsBefore may only be called if fBroadcastTransactions!
     std::vector<uint256> ResendWalletTransactionsBefore(int64_t nTime, CConnman* connman);
     CAmount GetBalance() const;
-    CAmount GetStakedBalance() const;
+    void GetStakedBalances(CAmount& total, CAmount& mempool, CAmount& immature, CAmount& live, CAmount& voted, CAmount& missed, CAmount& expired, CAmount& revoked) const;
     CAmount GetUnconfirmedBalance() const;
     CAmount GetImmatureBalance() const;
     CAmount GetWatchOnlyBalance() const;
@@ -1025,6 +1030,10 @@ public:
     CAmount GetImmatureWatchOnlyBalance() const;
     CAmount GetLegacyBalance(const isminefilter& filter, int minDepth, const std::string* account) const;
     CAmount GetAvailableBalance(const CCoinControl* coinControl = nullptr) const;
+    void GetRewardsAndRefunds(CAmount& rewards, CAmount& refunds) const;
+    CAmount GetMinedFunds() const;
+
+    CAmount GetTotalFees() const;
 
     /**
      * Insert additional inputs into the transaction by
@@ -1086,7 +1095,7 @@ public:
      * Returns amount of debit if the input matches the
      * filter, otherwise returns 0
      */
-    CAmount GetDebit(const CTxIn& txin, const isminefilter& filter) const;
+    CAmount GetDebit(const ETxClass txClass, const CTxIn& txIn, const isminefilter& filter) const;
     isminetype IsMine(const CTxOut& txout) const;
     CAmount GetCredit(const CTxOut& txOut, const isminefilter& filter) const;
     CAmount GetCredit(const ETxClass txClass, const uint32_t txIndex, const CTxOut& txOut, const isminefilter& filter) const;
@@ -1101,6 +1110,13 @@ public:
     CAmount GetCredit(const CTransaction& tx, const isminefilter& filter) const;
     CAmount GetChange(const CTransaction& tx) const;
     void SetBestChain(const CBlockLocator& loc) override;
+
+    void CleanupTransactions(const int height) override;
+
+    // return the hashes of all the descendants of a wallet transaction.
+    // optionally, check if the descendant is in a block or in mempool, i.e. not lingering in the wallet.
+    // if check is enabled and a descendant is either in blockchain or in mempool, the function returns false.
+    bool GetDescendants(const CWalletTx& wtx, std::vector<uint256>& descendants, bool checkLingering = true);
 
     DBErrors LoadWallet(bool& fFirstRunRet);
     DBErrors ZapWalletTx(std::vector<CWalletTx>& vWtx);


### PR DESCRIPTION
This PR contains the following major changes:
- removed the expired tickets from the wallet based on their expiration information and blockain/mempool presence;
- removed the ticket stake outputs, vote and revocation inputs from balance calculations;
- added detailed stake balances for various states;
- solved issues with the block template stake transactions list.