### PR TITLE
WIP: Restricted prioritization of stake transactions and chain tips

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -314,7 +314,10 @@ Connection options:
       height is calculated relative to the currently active chain tip. The chain
       tips are sent when the protocol handshake is done, but only if the initial
       block download is completed. A negative value means sending all chain tips.
-      (default, -1)
+      (default, 0)
+      
+  -handshaketipsinterval=<n>
+      The time interval in seconds to consider the peer in sync. (default, 60)
 
 Wallet options:
 

--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -3,6 +3,7 @@ $(package)_version=1_64_0
 $(package)_download_path=https://dl.bintray.com/boostorg/release/1.64.0/source/
 $(package)_file_name=$(package)_$($(package)_version).tar.bz2
 $(package)_sha256_hash=7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332
+$(package)_patches=40960b23338da0a359d6aa83585ace09ad8804d2.patch
 
 define $(package)_set_vars
 $(package)_config_opts_release=variant=release
@@ -25,7 +26,8 @@ $(package)_cxxflags_linux=-fPIC
 endef
 
 define $(package)_preprocess_cmds
-  echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam
+  echo "using $(boost_toolset_$(host_os)) : : $($(package)_cxx) : <cxxflags>\"$($(package)_cxxflags) $($(package)_cppflags)\" <linkflags>\"$($(package)_ldflags)\" <archiver>\"$(boost_archiver_$(host_os))\" <striper>\"$(host_STRIP)\"  <ranlib>\"$(host_RANLIB)\" <rc>\"$(host_WINDRES)\" : ;" > user-config.jam && \
+  patch -p0 < $($(package)_patch_dir)/40960b23338da0a359d6aa83585ace09ad8804d2.patch
 endef
 
 define $(package)_config_cmds

--- a/depends/patches/boost/40960b23338da0a359d6aa83585ace09ad8804d2.patch
+++ b/depends/patches/boost/40960b23338da0a359d6aa83585ace09ad8804d2.patch
@@ -1,0 +1,31 @@
+From 40960b23338da0a359d6aa83585ace09ad8804d2 Mon Sep 17 00:00:00 2001
+From: Bo Anderson <mail@boanderson.me>
+Date: Sun, 29 Mar 2020 14:55:08 +0100
+Subject: [PATCH] Fix compiler version check on macOS
+
+Fixes #440.
+---
+ tools/build/src/tools/darwin.jam | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/src/tools/darwin.jam b/src/tools/darwin.jam
+index 8d477410b0..97e7ecb851 100644
+--- ./tools/build/src/tools/darwin.jam
++++ ./tools/build/src/tools/darwin.jam
+@@ -137,13 +137,14 @@ rule init ( version ? : command * : options * : requirement * )
+     # - Set the toolset generic common options.
+     common.handle-options darwin : $(condition) : $(command) : $(options) ;
+     
++    real-version = [ regex.split $(real-version) \\. ] ;
+     # - GCC 4.0 and higher in Darwin does not have -fcoalesce-templates.
+-    if $(real-version) < "4.0.0"
++    if [ version.version-less $(real-version) : 4 0 ]
+     {
+         flags darwin.compile.c++ OPTIONS $(condition) : -fcoalesce-templates ;
+     }
+     # - GCC 4.2 and higher in Darwin does not have -Wno-long-double.
+-    if $(real-version) < "4.2.0"
++    if [ version.version-less $(real-version) : 4 2 ]
+     {
+         flags darwin.compile OPTIONS $(condition) : -Wno-long-double ;
+     }

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -48,7 +48,17 @@ Build PAI Coin Core
         git clone https://github.com/projectpai/paicoin
         cd paicoin
 
-2.  Build paicoin-core:
+2. If you have Catalina 10.15 or a higher version, then you must run this command:
+
+	If you have XCode installed:
+
+	export CPATH=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
+
+	If you have only the command-line tools:
+
+	CPATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/
+
+3.  Build paicoin-core:
 
     Configure and build the headless paicoin binaries as well as the GUI (if Qt is found).
 
@@ -61,11 +71,11 @@ Build PAI Coin Core
         CONFIG_SITE=`pwd`/depends/`build-aux/config.guess`/share/config.site ./configure
         make
 
-3.  It is recommended to build and run the unit tests:
+4.  It is recommended to build and run the unit tests:
 
         make check
 
-4.  You can also create a .dmg that contains the .app bundle (optional):
+5.  You can also create a .dmg that contains the .app bundle (optional):
 
         make deploy
 

--- a/src/help.txt
+++ b/src/help.txt
@@ -208,7 +208,10 @@ Connection options:
        height is calculated relative to the currently active chain tip. The chain
        tips are sent when the protocol handshake is done, but only if the initial
        block download is completed. A negative value means sending all chain tips.
-       (default, -1)
+       (default, 0)
+
+   -handshaketipsinterval=<n>
+       The time interval in seconds to consider the peer in sync. (default, 60)
 
 Wallet options:
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -419,6 +419,7 @@ std::string HelpMessage(HelpMessageMode mode)
         " " + _("Whitelisted peers cannot be DoS banned and their transactions are always relayed, even if they are already in the mempool, useful e.g. for a gateway"));
     strUsage += HelpMessageOpt("-maxuploadtarget=<n>", strprintf(_("Tries to keep outbound traffic under the given target (in MiB per 24h), 0 = no limit (default: %d)"), DEFAULT_MAX_UPLOAD_TARGET));
     strUsage += HelpMessageOpt("-handshaketipsdepth=<n>", strprintf(_("The maximum depth of chain tips to be sent on new connections. The actual height is calculated relative to the currently active chain tip. The chain tips are sent when the protocol handshake is done, but only if the initial block download is completed. A negative value means sending all chain tips. (default, %u)"), DEFAULT_HANDSHAKE_TIPS_DEPTH));
+    strUsage += HelpMessageOpt("-handshaketipsinterval=<n>", strprintf(_("The time interval in seconds to consider the peer in sync. (default, %u)"), DEFAULT_HANDSHAKE_TIPS_INTERVAL));
 
 #ifdef ENABLE_WALLET
     strUsage += GetWalletHelpString(showDebug);

--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -12,6 +12,7 @@
 #include "hash.h"
 #include "consensus/consensus.h"
 #include "utilstrencodings.h"
+#include "stake/staketx.h"
 
 
 CMerkleBlock::CMerkleBlock(const CBlock& block, CBloomFilter* filter, const std::set<uint256>* txids)
@@ -29,7 +30,7 @@ CMerkleBlock::CMerkleBlock(const CBlock& block, CBloomFilter* filter, const std:
         const uint256& hash = block.vtx[i]->GetHash();
         if (txids && txids->count(hash)) {
             vMatch.push_back(true);
-        } else if (filter && filter->IsRelevantAndUpdate(*block.vtx[i])) {
+        } else if (IsStakeTx(*block.vtx[i]) || (filter && filter->IsRelevantAndUpdate(*block.vtx[i]))) {
             vMatch.push_back(true);
             vMatchedTxn.emplace_back(i, hash);
         } else {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2701,6 +2701,7 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     fInbound(fInboundIn),
     nKeyedNetGroup(nKeyedNetGroupIn),
     addrKnown(5000, 0.001),
+    filterChainTipsKnown(50000, 0.000001),
     filterInventoryKnown(50000, 0.000001),
     id(idIn),
     nLocalHostNonce(nLocalHostNonceIn),
@@ -2731,6 +2732,7 @@ CNode::CNode(NodeId idIn, ServiceFlags nLocalServicesIn, int nMyStartingHeightIn
     nSendOffset = 0;
     hashContinue = uint256();
     nStartingHeight = -1;
+    filterChainTipsKnown.reset();
     filterInventoryKnown.reset();
     fSendMempool = false;
     fGetAddr = false;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -964,6 +964,12 @@ static void RelayTransaction(const CTransaction& tx, CConnman* connman)
     });
 }
 
+static void RelayTransaction(const CTransaction& tx, CNode* pnode)
+{
+    CInv inv(MSG_TX, tx.GetHash());
+    pnode->PushInventory(inv);
+}
+
 static void RelayAddress(const CAddress& addr, bool fReachable, CConnman* connman)
 {
     unsigned int nRelayNodes = fReachable ? 2 : 1; // limited relaying of addresses outside our network(s)
@@ -1000,32 +1006,42 @@ static void RelayAddress(const CAddress& addr, bool fReachable, CConnman* connma
     connman->ForEachNodeThen(std::move(sortfunc), std::move(pushfunc));
 }
 
-void static SendAllMempoolVotes(CNode* pfrom, CConnman* connman, const std::atomic<bool>& interruptMsgProc)
+void static RelayMempoolStakeTxs(CNode* pfrom)
 {
-    const CNetMsgMaker msgMaker(pfrom->GetSendVersion());
-    int nSendFlags = 0;
+    // add all the stake transactions in the specified order (this is reversed when sending).
+    // also add all regular transactions that fund ticket purchases.
 
     LOCK(cs_main);
 
+    std::set<uint256> fundingTxIds;
+
     auto& tx_class_index = mempool.mapTx.get<tx_class>();
-    auto votes = tx_class_index.equal_range(ETxClass::TX_Vote);
 
-    for (auto votetxiter = votes.first; votetxiter != votes.second; ++votetxiter) {
-        if (pfrom->fPauseSend)
-            break;
+    auto revocations = tx_class_index.equal_range(TX_RevokeTicket);
+    for (auto txiter = revocations.first; txiter != revocations.second; ++txiter)
+        RelayTransaction(txiter->GetTx(), pfrom);
 
-        if (interruptMsgProc)
-            return;
+    auto tickets = tx_class_index.equal_range(TX_BuyTicket);
+    for (auto txiter = tickets.first; txiter != tickets.second; ++txiter) {
+        const auto& tx = txiter->GetTx();
+        RelayTransaction(tx, pfrom);
+        for (auto txIn: tx.vin)
+            fundingTxIds.insert(txIn.prevout.hash);
+    }
 
-        const auto& vote = votetxiter->GetTx();
+    auto votes = tx_class_index.equal_range(TX_Vote);
+    for (auto txiter = votes.first; txiter != votes.second; ++txiter)
+        RelayTransaction(txiter->GetTx(), pfrom);
 
-        nSendFlags = (vote.HasWitness() ? SERIALIZE_TRANSACTION_NO_WITNESS : 0);
-
-        connman->PushMessage(pfrom, msgMaker.Make(nSendFlags, NetMsgType::TX, vote));
+    auto regulars = tx_class_index.equal_range(TX_Regular);
+    for (auto txiter = regulars.first; txiter != regulars.second; ++txiter) {
+        const auto& tx = txiter->GetTx();
+        if (fundingTxIds.count(tx.GetHash()) > 0)
+            RelayTransaction(tx, pfrom);
     }
 }
 
-void static SendChainTips(CNode* pfrom, const Consensus::Params& consensusParams, CConnman* connman, const std::atomic<bool>& interruptMsgProc, const int maxDepth = DEFAULT_HANDSHAKE_TIPS_DEPTH)
+void static RelayChainTips(CNode* pfrom, const Consensus::Params& consensusParams, CConnman* connman, const std::atomic<bool>& interruptMsgProc, const int maxDepth = DEFAULT_HANDSHAKE_TIPS_DEPTH, CBlock *pExcludeBlock = nullptr)
 {
     const CNetMsgMaker msgMaker(pfrom->GetSendVersion());
 
@@ -1043,7 +1059,11 @@ void static SendChainTips(CNode* pfrom, const Consensus::Params& consensusParams
         setLatestTips = setTips;
     }
 
-    for (const CBlockIndex* pindex: setTips) {
+    uint256 excludeHash;
+    if (pExcludeBlock)
+        excludeHash = pExcludeBlock->GetHash();
+
+    for (const CBlockIndex* pindex: setLatestTips) {
         if (pfrom->fPauseSend)
             break;
 
@@ -1053,6 +1073,9 @@ void static SendChainTips(CNode* pfrom, const Consensus::Params& consensusParams
         if ((pindex->nStatus & BLOCK_HAVE_DATA) == 0)
             continue;
 
+        if (pExcludeBlock && (pindex->GetBlockHash() == excludeHash))
+            continue;
+
         // Send block from disk
         std::shared_ptr<const CBlock> pblock;
         std::shared_ptr<CBlock> pblockRead = std::make_shared<CBlock>();
@@ -1060,8 +1083,42 @@ void static SendChainTips(CNode* pfrom, const Consensus::Params& consensusParams
             continue;
         pblock = pblockRead;
 
-        connman->PushMessage(pfrom, msgMaker.Make(SERIALIZE_TRANSACTION_NO_WITNESS, NetMsgType::BLOCK, *pblock));
+        pfrom->PushChainTip(*pblock);
     }
+}
+
+void static RelayStakeTxsAndChainTipsIfNeeded(CBlock block, CNode* pfrom, const Consensus::Params& consensusParams, CConnman* connman, const std::atomic<bool>& interruptMsgProc, uint256 chainTipHash = uint256())
+{
+    // send all the votes in mempool and the chain tips,
+    // if not during the initial block download
+    // and the peer is at the same height as us.
+    // Height is estimated based on timestamps.
+
+    if (IsInitialBlockDownload())
+        return;
+
+    if (!pfrom || !connman)
+        return;
+
+    //int64_t chainTipTime = 0LL;
+    if (chainTipHash == uint256()) {
+        LOCK(cs_main);
+        //chainTipTime = chainActive.Tip()->GetBlockTime();
+        chainTipHash = chainActive.Tip()->GetBlockHash();
+    }
+
+    //int64_t tipsInterval = gArgs.GetArg("-handshaketipsinterval", DEFAULT_HANDSHAKE_TIPS_INTERVAL);
+
+    //if ((pfrom->nLastBlockTime < chainTipTime - tipsInterval) || (pfrom->nLastBlockTime > chainTipTime + tipsInterval))
+    //    return;
+
+    if (block.GetHash() != chainTipHash)
+        return;
+
+    RelayMempoolStakeTxs(pfrom);
+
+    int depth = static_cast<int>(gArgs.GetArg("-handshaketipsdepth", DEFAULT_HANDSHAKE_TIPS_DEPTH));
+    RelayChainTips(pfrom, consensusParams, connman, interruptMsgProc, depth, &block);
 }
 
 void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParams, CConnman* connman, const std::atomic<bool>& interruptMsgProc)
@@ -1144,10 +1201,14 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                             assert(!"cannot load block from disk");
                         pblock = pblockRead;
                     }
-                    if (inv.type == MSG_BLOCK)
+                    if (inv.type == MSG_BLOCK) {
                         connman->PushMessage(pfrom, msgMaker.Make(SERIALIZE_TRANSACTION_NO_WITNESS, NetMsgType::BLOCK, *pblock));
-                    else if (inv.type == MSG_WITNESS_BLOCK)
+                        RelayStakeTxsAndChainTipsIfNeeded(*pblock, pfrom, consensusParams, connman, interruptMsgProc, chainActive.Tip()->GetBlockHash());
+                    }
+                    else if (inv.type == MSG_WITNESS_BLOCK) {
                         connman->PushMessage(pfrom, msgMaker.Make(NetMsgType::BLOCK, *pblock));
+                        RelayStakeTxsAndChainTipsIfNeeded(*pblock, pfrom, consensusParams, connman, interruptMsgProc, chainActive.Tip()->GetBlockHash());
+                    }
                     else if (inv.type == MSG_FILTERED_BLOCK)
                     {
                         bool sendMerkleBlock = false;
@@ -1191,6 +1252,7 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
                             }
                         } else {
                             connman->PushMessage(pfrom, msgMaker.Make(nSendFlags, NetMsgType::BLOCK, *pblock));
+                            RelayStakeTxsAndChainTipsIfNeeded(*pblock, pfrom, consensusParams, connman, interruptMsgProc, chainActive.Tip()->GetBlockHash());
                         }
                     }
 
@@ -1546,12 +1608,20 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         }
         pfrom->fSuccessfullyConnected = true;
 
-        // send all the votes in mempool and the chain tips, if not during the initial block download
+        // if the peer is at the same height with us,
+        // then send it all the votes and chaintips we have
         if (!IsInitialBlockDownload()) {
-            SendAllMempoolVotes(pfrom, connman, interruptMsgProc);
+            int64_t tipHeight = 0;
+            {
+                LOCK(cs_main);
+                tipHeight = chainActive.Tip()->nHeight;
+            }
+            if (pfrom->nStartingHeight == tipHeight) {
+                RelayMempoolStakeTxs(pfrom);
 
-            int depth = static_cast<int>(gArgs.GetArg("-handshaketipsdepth", DEFAULT_HANDSHAKE_TIPS_DEPTH));
-            SendChainTips(pfrom, chainparams.GetConsensus(), connman, interruptMsgProc, depth);
+                int depth = static_cast<int>(gArgs.GetArg("-handshaketipsdepth", DEFAULT_HANDSHAKE_TIPS_DEPTH));
+                RelayChainTips(pfrom, chainparams.GetConsensus(), connman, interruptMsgProc, depth);
+            }
         }
     }
 
@@ -2575,6 +2645,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         ProcessNewBlock(chainparams, pblock, forceProcessing, &fNewBlock);
         if (fNewBlock) {
             pfrom->nLastBlockTime = GetTime();
+            RelayStakeTxsAndChainTipsIfNeeded(*pblock, pfrom, chainparams.GetConsensus(), connman, interruptMsgProc);
         } else {
             LOCK(cs_main);
             mapBlockSource.erase(pblock->GetHash());
@@ -3095,6 +3166,19 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
                 pto->vAddrToSend.shrink_to_fit();
         }
 
+        // Send chain tips, if available
+        {
+            LOCK(pto->cs_chainTips);
+            for (auto& block : pto->vChainTipsToSend) {
+                const uint256& hash = block.GetHash();
+                if (!pto->filterChainTipsKnown.contains(hash)) {
+                    connman->PushMessage(pto, msgMaker.Make(SERIALIZE_TRANSACTION_NO_WITNESS, NetMsgType::BLOCK, block));
+                    pto->filterChainTipsKnown.insert(hash);
+                }
+            }
+            pto->vChainTipsToSend.clear();
+        }
+
         // Start block sync
         if (pindexBestHeader == nullptr)
             pindexBestHeader = chainActive.Tip();
@@ -3317,11 +3401,12 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
                     const uint256& hash = txinfo.tx->GetHash();
                     CInv inv(MSG_TX, hash);
                     pto->setInventoryTxToSend.erase(hash);
+                    ETxClass txClass = ParseTxClass(*txinfo.tx);
                     if (filterrate) {
-                        if (txinfo.feeRate.GetFeePerK() < filterrate && ParseTxClass(*txinfo.tx) != TX_Vote)
+                        if (txinfo.feeRate.GetFeePerK() < filterrate && txClass != TX_Vote)
                             continue;
                     }
-                    if (pto->pfilter) {
+                    if (!IsStakeTx(txClass) && pto->pfilter) {
                         if (!pto->pfilter->IsRelevantAndUpdate(*txinfo.tx)) continue;
                     }
                     pto->filterInventoryKnown.insert(hash);
@@ -3372,10 +3457,11 @@ bool PeerLogicValidation::SendMessages(CNode* pto)
                     if (!txinfo.tx) {
                         continue;
                     }
-                    if (filterrate && txinfo.feeRate.GetFeePerK() < filterrate && ParseTxClass(*txinfo.tx) != TX_Vote) {
+                    ETxClass txClass = ParseTxClass(*txinfo.tx);
+                    if (filterrate && txinfo.feeRate.GetFeePerK() < filterrate && txClass != TX_Vote) {
                         continue;
                     }
-                    if (pto->pfilter && !pto->pfilter->IsRelevantAndUpdate(*txinfo.tx)) continue;
+                    if (!IsStakeTx(txClass) && pto->pfilter && !pto->pfilter->IsRelevantAndUpdate(*txinfo.tx)) continue;
                     // Send
                     vInv.push_back(CInv(MSG_TX, hash));
                     nRelayedTransactions++;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -21,7 +21,9 @@ static const int64_t ORPHAN_TX_EXPIRE_INTERVAL = 5 * 60;
 /** Default number of orphan+recently-replaced txn to keep around for block reconstruction */
 static const unsigned int DEFAULT_BLOCK_RECONSTRUCTION_EXTRA_TXN = 100;
 /** Default depth from which the chain tips will be automatically sent on peer connection handshake finalization (-1 means all chain tips) */
-static const int DEFAULT_HANDSHAKE_TIPS_DEPTH = -1;
+static const int DEFAULT_HANDSHAKE_TIPS_DEPTH = 0;
+/** Default time lag in seconds to consider the peer in sync */
+static const int DEFAULT_HANDSHAKE_TIPS_INTERVAL = 1*60;
 /** Headers download timeout expressed in microseconds
  *  Timeout = base + per_header * (expected number of headers) */
 static constexpr int64_t HEADERS_DOWNLOAD_TIMEOUT_BASE = 15 * 60 * 1000000; // 15 minutes

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -25,6 +25,10 @@
 #include <QDebug>
 #include <QTimer>
 
+#if BOOST_VERSION >= 106000
+using namespace boost::placeholders;
+#endif
+
 class CBlockIndex;
 
 static int64_t nLastHeaderTipUpdateNotification = 0;

--- a/src/qt/paicoingui.cpp
+++ b/src/qt/paicoingui.cpp
@@ -78,6 +78,10 @@ const std::string PAIcoinGUI::DEFAULT_UIPLATFORM =
 #endif
         ;
 
+#if BOOST_VERSION >= 106000
+using namespace boost::placeholders;
+#endif
+
 /** Display name for default wallet name. Uses tilde to avoid name
  * collisions in the future with additional wallets */
 const QString PAIcoinGUI::DEFAULT_WALLET = "~Default";

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -30,6 +30,10 @@
 #include <QPainter>
 #include <QRadialGradient>
 
+#if BOOST_VERSION >= 106000
+using namespace boost::placeholders;
+#endif
+
 SplashScreen::SplashScreen(Qt::WindowFlags f, const NetworkStyle *networkStyle) :
     QWidget(0, f), curAlignment(0)
 {

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -30,6 +30,10 @@
 #include <QIcon>
 #include <QList>
 
+#if BOOST_VERSION >= 106000
+using namespace boost::placeholders;
+#endif
+
 // Amount column is right-aligned it contains numbers
 static int column_alignments[] = {
         Qt::AlignLeft|Qt::AlignVCenter, /* status */

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -40,6 +40,9 @@
 #include <QSet>
 #include <QTimer>
 
+#if BOOST_VERSION >= 106000
+using namespace boost::placeholders;
+#endif
 
 WalletModel::WalletModel(const PlatformStyle *platformStyle, CWallet *_wallet, OptionsModel *_optionsModel, QObject *parent) :
     QObject(parent), wallet(_wallet), optionsModel(_optionsModel), addressTableModel(0),

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -30,6 +30,10 @@
 #include <unordered_map>
 #include <iterator>
 
+#if BOOST_VERSION >= 106000
+using namespace boost::placeholders;
+#endif
+
 static auto fRPCRunning = false;
 static auto fRPCInWarmup = true;
 static std::string rpcWarmupStatus{"RPC server started"};
@@ -515,7 +519,7 @@ std::vector<std::string> CRPCTable::listCommands() const
 
     std::transform( std::begin(mapCommands), std::end(mapCommands),
                    std::back_inserter(commandList),
-                   boost::bind(&commandMap::value_type::first,_1) );
+                   boost::bind(&commandMap::value_type::first, _1) );
     return commandList;
 }
 

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -24,6 +24,10 @@
 #include <event2/event.h>
 #include <event2/thread.h>
 
+#if BOOST_VERSION >= 106000
+using namespace boost::placeholders;
+#endif
+
 /** Default control port */
 const std::string DEFAULT_TOR_CONTROL = "127.0.0.1:9051";
 /** Tor cookie size (from control-spec.txt) */

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -14,6 +14,10 @@
 
 #include <boost/signals2/signal.hpp>
 
+#if BOOST_VERSION >= 106000
+using namespace boost::placeholders;
+#endif
+
 struct MainSignalsInstance {
     boost::signals2::signal<void (const CBlockIndex *, const CBlockIndex *, bool fInitialDownload)> UpdatedBlockTip;
     boost::signals2::signal<void (const CTransactionRef &)> TransactionAddedToMempool;


### PR DESCRIPTION
This PR ensures that stake transactions and chain tip prioritization respects the appropriate block chain state by:
- sending stake vouchers, votes and revocations with priority;
- sending only the chain tips at the current active height;
- sending the stake transactions and chain tips when the two peers of a connection are in sync;
- not sending stake transactions that the peer already has, as it's being known by the sender;

Some Boost compatibility issues are also addressed by this PR.